### PR TITLE
fix issues with circular dependencies in ml-wrappers (dependencies on interpret-community)

### DIFF
--- a/python/ml_wrappers/common/gpu_kmeans.py
+++ b/python/ml_wrappers/common/gpu_kmeans.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+The code is based on the similar utility function from SHAP:
+https://github.com/slundberg/shap/blob/9411b68e8057a6c6f3621765b89b24d82bee13d4/shap/utils/_legacy.py
+This version makes use of cuml kmeans instead of sklearn for speed.
+"""
+
+import numpy as np
+
+try:
+    import cuml
+    from cuml import KMeans
+    from cuml.preprocessing import SimpleImputer
+    rapids_installed = True
+except BaseException:
+    rapids_installed = False
+from scipy.sparse import issparse
+
+
+def kmeans(X, k, round_values=True):
+    """ Summarize a dataset with k mean samples weighted by the number of data points they
+    each represent.
+    Parameters
+    ----------
+    X : numpy.array or pandas.DataFrame or any scipy.sparse matrix
+        Matrix of data samples to summarize (# samples x # features)
+    k : int
+        Number of means to use for approximation.
+    round_values : bool
+        For all i, round the ith dimension of each mean sample to match the nearest value
+        from X[:,i]. This ensures discrete features always get a valid value.
+    Returns
+    -------
+    DenseData object.
+    """
+
+    if not rapids_installed:
+        raise RuntimeError(
+            "cuML is required to use GPU explainers. Check https://rapids.ai/start.html \
+            for more information on how to install it.")
+    if cuml.__version__ >= '21.08':
+        from cuml.explainer.sampling import kmeans_sampling
+        summary, group_names, labels = kmeans_sampling(X, k, round_values, detailed=True)
+
+        return DenseData(summary,
+                         group_names,
+                         None,
+                         1.0 * np.bincount(labels))
+    # For backward compatibility
+    group_names = [str(i) for i in range(X.shape[1])]
+    if str(type(X)).endswith("'pandas.core.frame.DataFrame'>"):
+        group_names = X.columns
+        X = X.values
+
+    # in case there are any missing values in data impute them
+    imp = SimpleImputer(missing_values=np.nan, strategy='mean')
+    X = imp.fit_transform(X)
+
+    kmeans = KMeans(n_clusters=k, random_state=0).fit(X)
+
+    if round_values:
+        for i in range(k):
+            for j in range(X.shape[1]):
+                xj = X[:, j].toarray().flatten() if issparse(
+                    X) else X[:, j]  # sparse support courtesy of @PrimozGodec
+                ind = np.argmin(np.abs(xj - kmeans.cluster_centers_[i, j]))
+                kmeans.cluster_centers_[i, j] = X[ind, j]
+    return DenseData(
+        kmeans.cluster_centers_,
+        group_names,
+        None,
+        1.0 *
+        np.bincount(
+            kmeans.labels_))
+
+
+class Data:
+    def __init__(self):
+        pass
+
+
+class DenseData(Data):
+    def __init__(self, data, group_names, *args):
+        self.groups = args[0] if len(args) > 0 and args[0] is not None else [
+            np.array([i]) for i in range(len(group_names))]
+
+        length = sum(len(g) for g in self.groups)
+        num_samples = data.shape[0]
+        t = False
+        if length != data.shape[1]:
+            t = True
+            num_samples = data.shape[1]
+
+        valid = (
+            not t and length == data.shape[1]) or (
+            t and length == data.shape[0])
+        assert valid, "# of names must match data matrix!"
+
+        self.weights = args[1] if len(args) > 1 else np.ones(num_samples)
+        self.weights /= np.sum(self.weights)
+        wl = len(self.weights)
+        valid = (not t and wl == data.shape[0]) or (t and wl == data.shape[1])
+        assert valid, "# weights must match data matrix!"
+
+        self.transposed = t
+        self.group_names = group_names
+        self.data = data
+        self.groups_size = len(self.groups)

--- a/python/ml_wrappers/dataset/dataset_utils.py
+++ b/python/ml_wrappers/dataset/dataset_utils.py
@@ -1,0 +1,84 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+"""Defines helpful utilities for the DatasetWrapper."""
+
+import logging
+import warnings
+
+import numpy as np
+from scipy.sparse import csr_matrix, issparse
+from scipy.sparse import vstack as sparse_vstack
+from sklearn.utils import shuffle
+from sklearn.utils.sparsefuncs import csc_median_axis_0
+from ..common.gpu_kmeans import kmeans
+
+with warnings.catch_warnings():
+    warnings.filterwarnings('ignore', 'Starting from version 2.2.1', UserWarning)
+    try:
+        import shap
+        shap_installed = True
+    except BaseException:
+        shap_installed = False
+
+module_logger = logging.getLogger(__name__)
+module_logger.setLevel(logging.INFO)
+
+
+def _generate_augmented_data(x, max_num_of_augmentations=np.inf):
+    """Augment x by appending x with itself shuffled columnwise many times.
+
+    :param x: data that has to be augmented, array or sparse matrix of 2 dimensions
+    :type x: numpy.array or scipy.sparse.csr_matrix
+    :param max_augment_data_size: number of times we stack permuted x to augment.
+    :type max_augment_data_size: int
+    :return: augmented data with roughly number of rows that are equal to number of columns
+    :rtype: numpy.array or scipy.sparse.csr_matrix
+    """
+    x_augmented = x
+    vstack = sparse_vstack if issparse(x) else np.vstack
+    for i in range(min(x.shape[1] // x.shape[0] - 1, max_num_of_augmentations)):
+        x_permuted = shuffle(x.T, random_state=i).T
+        x_augmented = vstack([x_augmented, x_permuted])
+
+    return x_augmented
+
+
+def _summarize_data(X, k=10, use_gpu=False, to_round_values=True):
+    """Summarize a dataset.
+
+    For dense dataset, use k mean samples weighted by the number of data points they
+    each represent.
+    For sparse dataset, use a sparse row for the background with calculated
+    median for dense columns.
+
+    :param X: Matrix of data samples to summarize (# samples x # features).
+    :type X: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+    :param k: Number of cluster centroids to use for approximation.
+    :type k: int
+    :param to_round_values: When using kmeans, for each element of every cluster centroid to match the nearest value
+        from X in the corresponding dimension. This ensures discrete features
+        always get a valid value.  Ignored for sparse data sample.
+    :type to_round_values: bool
+    :return: summarized numpy array or csr_matrix object.
+    :rtype: numpy.array or scipy.sparse.csr_matrix or DenseData
+    """
+    is_sparse = issparse(X)
+    if not str(type(X)).endswith(".DenseData'>"):
+        if is_sparse:
+            module_logger.debug('Creating sparse data summary as csr matrix')
+            # calculate median of sparse background data
+            median_dense = csc_median_axis_0(X.tocsc())
+            return csr_matrix(median_dense)
+        elif len(X) > 10 * k:
+            module_logger.debug('Create dense data summary with k-means')
+            # use kmeans to summarize the examples for initialization
+            # if there are more than 10 x k of them
+            if use_gpu:
+                return kmeans(X, k, to_round_values)
+            else:
+                if not shap_installed:
+                    raise RuntimeError('shap is required to compute dataset summary in DatasetWrapper')
+                return shap.kmeans(X, k, to_round_values)
+    return X

--- a/python/ml_wrappers/dataset/dataset_wrapper.py
+++ b/python/ml_wrappers/dataset/dataset_wrapper.py
@@ -13,12 +13,7 @@ from scipy.sparse import issparse
 
 from ..common.constants import Defaults
 from .timestamp_featurizer import CustomTimestampFeaturizer
-try:
-    from interpret_community.common.explanation_utils import (
-        _generate_augmented_data, _summarize_data)
-    interpret_installed = True
-except BaseException:
-    interpret_installed = False
+from .dataset_utils import _generate_augmented_data, _summarize_data
 
 with warnings.catch_warnings():
     warnings.filterwarnings('ignore', 'Starting from version 2.2.1', UserWarning)
@@ -383,8 +378,6 @@ class DatasetWrapper(object):
 
     def compute_summary(self, nclusters=10, use_gpu=False, **kwargs):
         """Summarizes the dataset if it hasn't been summarized yet."""
-        if not interpret_installed:
-            raise RuntimeError('interpret-community is required to compute dataset summary in DatasetWrapper')
         if self._summary_computed:
             return
         self._summary_dataset = _summarize_data(self._dataset, nclusters, use_gpu)
@@ -397,8 +390,6 @@ class DatasetWrapper(object):
         :param max_augment_data_size: number of times we stack permuted x to augment.
         :type max_augment_data_size: int
         """
-        if not interpret_installed:
-            raise RuntimeError('interpret-community is required to augment data in DatasetWrapper')
         self._dataset = _generate_augmented_data(self._dataset, max_num_of_augmentations=max_num_of_augmentations)
 
     def take_subset(self, explain_subset):


### PR DESCRIPTION
fix circular dependency errors in ml-wrappers due to imports from interpret-community
Note:
_generate_augmented_data and _summarize_data are now moved inside ml-wrappers, including gpu_kmeans code which used to be in interpret-community