### PR TITLE
fix imports in model init file to include WrappedClassificationModel and WrappedRegressionModel

### DIFF
--- a/python/ml_wrappers/model/__init__.py
+++ b/python/ml_wrappers/model/__init__.py
@@ -4,6 +4,8 @@
 
 """Common infrastructure, class hierarchy and utilities for model explanations."""
 
-from .model_wrapper import WrappedPytorchModel, _wrap_model, wrap_model
+from .model_wrapper import (WrappedClassificationModel, WrappedPytorchModel,
+                            WrappedRegressionModel, _wrap_model, wrap_model)
 
-__all__ = ['_wrap_model', 'wrap_model', 'WrappedPytorchModel']
+__all__ = ['WrappedClassificationModel', 'WrappedPytorchModel',
+           'WrappedRegressionModel', '_wrap_model', 'wrap_model']


### PR DESCRIPTION
a downstream package has issues because it reimported these from interpret-community, which did not reimport them from ml-wrappers