### PR TITLE
add support for tensorflow BatchDataset to DatasetWrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ The dataset wrapper handles a variety of different dataset types and converts th
 
 The dataset wrapper simply converts the input to the common format, and after the common code finishes running, we convert the representation back to the original format, which can be handled by the original model.
 
+Currently supported data types include:
+
+- numpy.ndarray
+- pandas.DataFrame
+- panads.Series
+- scipy.sparse.csr_matrix
+- shap.DenseData
+- torch.Tensor
+- tensorflow.python.data.ops.dataset_ops.BatchDataset
+
 For more information about common format from the wrappers, please see the [Wrapper Specifications](https://github.com/microsoft/ml-wrappers/tree/main/docs/WrapperSpecifications.md) documentation.
 
 ## Installation

--- a/python/ml_wrappers/dataset/dataset_utils.py
+++ b/python/ml_wrappers/dataset/dataset_utils.py
@@ -82,3 +82,29 @@ def _summarize_data(X, k=10, use_gpu=False, to_round_values=True):
                     raise RuntimeError('shap is required to compute dataset summary in DatasetWrapper')
                 return shap.kmeans(X, k, to_round_values)
     return X
+
+
+def _convert_batch_dataset_to_numpy(batch_dataset):
+    """Convert a TensorFlow batch dataset to a numpy array.
+
+    :param batch_dataset: batch dataset to convert
+    :type batch_dataset: BatchDataset
+    :return: data, feature names and batch size
+    :rtype: numpy.ndarray, list, int
+    """
+    batches = []
+    set_keys = False
+    features = []
+    batch_size = 0
+    for data, _ in batch_dataset:
+        columns = []
+        for column in data.values():
+            columns.append(np.array(column))
+        if not set_keys:
+            for key in data.keys():
+                features.append(key)
+            batch_size = columns[0].shape[0]
+            set_keys = True
+        batches.append(np.stack(columns, axis=1))
+    converted_data = np.vstack(batches)
+    return converted_data, features, batch_size

--- a/tests/test_dataset_wrapper.py
+++ b/tests/test_dataset_wrapper.py
@@ -7,12 +7,19 @@
 import numpy as np
 import pandas as pd
 import pytest
+from common_utils import assert_batch_equal, assert_sparse_equal
 from ml_wrappers.dataset.dataset_utils import _summarize_data
 from ml_wrappers.dataset.dataset_wrapper import DatasetWrapper
+from pandas.testing import assert_frame_equal, assert_series_equal
 from scipy.sparse import csr_matrix
 
 try:
     import torch
+except ImportError:
+    pass
+
+try:
+    import tensorflow as tf
 except ImportError:
     pass
 
@@ -21,23 +28,40 @@ except ImportError:
 class TestDatasetWrapper(object):
     def test_supported_types(self):
         test_dataframe = pd.DataFrame(data=[[1, 2, 3]], columns=['c1,', 'c2', 'c3'])
-        DatasetWrapper(dataset=test_dataframe)
+        wrapper = DatasetWrapper(dataset=test_dataframe)
+        df_converted = wrapper.typed_dataset
+        assert_frame_equal(df_converted, test_dataframe)
 
         test_array = test_dataframe.values
-        DatasetWrapper(dataset=test_array)
+        wrapper = DatasetWrapper(dataset=test_array)
+        numpy_converted = wrapper.typed_dataset
+        assert np.array_equal(numpy_converted, test_array)
 
-        test_series = test_dataframe.squeeze()
-        DatasetWrapper(dataset=test_series)
+        test_series = test_dataframe.squeeze().reset_index(drop=True)
+        wrapper = DatasetWrapper(dataset=test_series)
+        series_converted = wrapper.typed_dataset
+        assert_series_equal(series_converted, test_series,
+                            check_names=False)
 
         sparse_matrix = csr_matrix((3, 4),
                                    dtype=np.int8)
-        DatasetWrapper(dataset=sparse_matrix)
+        wrapper = DatasetWrapper(dataset=sparse_matrix)
+        sparse_matrix_converted = wrapper.typed_dataset
+        assert_sparse_equal(sparse_matrix_converted, sparse_matrix)
 
         background = _summarize_data(test_dataframe.values)
         DatasetWrapper(dataset=background)
 
         torch_input = torch.rand(100, 3)
-        DatasetWrapper(dataset=torch_input)
+        wrapper = DatasetWrapper(dataset=torch_input)
+        torch_converted = wrapper.typed_dataset
+        assert torch.all(torch.eq(torch_converted, torch_input))
+
+        tensor_slices = (dict(test_dataframe), None)
+        tf_batch_dataset = tf.data.Dataset.from_tensor_slices(tensor_slices).batch(32)
+        wrapper = DatasetWrapper(dataset=tf_batch_dataset)
+        tf_batch_dataset_converted = wrapper.typed_dataset
+        assert_batch_equal(tf_batch_dataset_converted, tf_batch_dataset)
 
     def test_unsupported_types(self):
         test_dataframe = pd.DataFrame(data=[[1, 2, 3]], columns=['c1,', 'c2', 'c3'])


### PR DESCRIPTION
Add support for tensorflow BatchDataset to DatasetWrapper.

The BatchDataset is converted to internal numpy format for processing.

Resolves user issue:
https://github.com/interpretml/interpret-community/issues/503

Also, adds more thorough roundtrip tests for the various types supported by DatasetWrapper, and adds a test for wrapping a tensorflow model that operates on a BatchDataset.
