### PR TITLE
Update requirements-linting.txt to remove flake8-nb

### DIFF
--- a/requirements-linting.txt
+++ b/requirements-linting.txt
@@ -4,6 +4,5 @@ flake8-blind-except==0.1.1
 flake8-breakpoint
 flake8-builtins==1.5.3
 flake8-logging-format==0.6.0
-flake8-nb==0.3.0
 flake8-pytest-style
 isort


### PR DESCRIPTION
It seems the linting building is broken to due a breaking change in nbconvert which is because of importing from flake8-nb.

```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/flake[8](https://github.com/microsoft/ml-wrappers/runs/5880733704?check_suite_focus=true#step:6:8)/plugins/manager.py", line 157, in load_plugin
    self._load()
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/flake8/plugins/manager.py", line 134, in _load
    self._plugin = self.entry_point.load()
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/importlib_metadata/__init__.py", line 203, in load
    module = import_module(match.group('module'))
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line [9](https://github.com/microsoft/ml-wrappers/runs/5880733704?check_suite_focus=true#step:6:9)83, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/flake8_nb/__init__.py", line 9, in <module>
    from flake8_nb.flake8_integration.formatter import IpynbFormatter
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/flake8_nb/flake8_integration/formatter.py", line 14, in <module>
    from flake8_nb.parsers.notebook_parsers import NotebookParser
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/flake8_nb/parsers/notebook_parsers.py", line 17, in <module>
    from nbconvert.filters import ipython2python
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/nbconvert/__init__.py", line 4, in <module>
    from .exporters import *
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/nbconvert/exporters/__init__.py", line 3, in <module>
    from .html import HTMLExporter
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/nbconvert/exporters/html.py", line 26, in <module>
    from nbconvert.filters.highlight import Highlight2HTML
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/nbconvert/filters/__init__.py", line 6, in <module>
    from .markdown import *
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/nbconvert/filters/markdown.py", line 23, in <module>
    from .pandoc import convert_pandoc
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/nbconvert/filters/pandoc.py", line 1, in <module>
    from nbconvert.utils.pandoc import pandoc
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/nbconvert/utils/pandoc.py", line 12, in <module>
    from nbconvert.utils.version import check_version
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/nbconvert/utils/version.py", line [11](https://github.com/microsoft/ml-wrappers/runs/5880733704?check_suite_focus=true#step:6:11), in <module>
    from packaging.version import Version
ModuleNotFoundError: No module named 'packaging'
```

However, looks like flake8-nb is not used for any linting in this repo. Hence, removing it.