### PR TITLE
add pypi prod and test release workflow github action to ml-wrappers repository

### DIFF
--- a/.github/workflows/release-ml-wrappers.yml
+++ b/.github/workflows/release-ml-wrappers.yml
@@ -1,0 +1,94 @@
+name: Release ml-wrappers to PyPI
+
+# trigger manually only ("collaborator" or more permissions required)
+on:
+  workflow_dispatch:
+    inputs:
+      releaseType:
+        description: "Test or Prod PyPI?"
+        required: true
+        default: "Test"
+
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: fail if Test nor Prod
+        if: ${{ ! (github.event.inputs.releaseType == 'Test' || github.event.inputs.releaseType == 'Prod') }}
+        run: |
+          echo "Only Test or Prod can be used."
+          exit 1
+
+      - uses: actions/checkout@v3
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: 3.7
+
+      - if: ${{ matrix.operatingSystem != 'macos-latest' }}
+        name: Install pytorch on non-MacOS
+        shell: bash -l {0}
+        run: |
+          conda install --yes --quiet pytorch torchvision captum cpuonly -c pytorch
+
+      - if: ${{ matrix.operatingSystem == 'macos-latest' }}
+        name: Install Anaconda packages on MacOS, which should not include cpuonly according to official docs
+        shell: bash -l {0}
+        run: |
+          conda install --yes --quiet pytorch torchvision captum -c pytorch
+
+      - name: update and upgrade pip, setuptools, wheel, and twine
+        shell: bash -l {0}
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade setuptools wheel twine
+
+      - name: install requirements for ml-wrappers
+        shell: bash -l {0}
+        run: |
+          pip install -r requirements-dev.txt
+          pip install -r requirements-test.txt
+
+      - name: pip freeze
+        shell: bash -l {0}
+        run: pip freeze
+
+      - name: build wheel for ml-wrappers
+        shell: bash -l {0}
+        run: python setup.py sdist bdist_wheel
+        working-directory: python
+
+      # run tests before publishing to PyPI
+      - name: install ml-wrappers wheel locally
+        shell: bash -l {0}
+        run: find ./dist/ -name '*.whl' -exec pip install {} \;
+        working-directory: python
+
+      - name: run ml-wrappers tests
+        shell: bash -l {0}
+        run: pytest ./tests/
+
+      - name: Upload a ml-wrappers build result
+        uses: actions/upload-artifact@v2
+        with:
+          name: ./python
+          path: ./python/dist/
+
+      # publish to PyPI
+      - name: Publish ml-wrappers package to Test PyPI
+        if: ${{ github.event.inputs.releaseType == 'Test' }}
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN_ML_WRAPPERS }}
+          repository_url: https://test.pypi.org/legacy/
+          packages_dir: python/dist/
+      - name: Publish ml-wrappers package to PyPI
+        if: ${{ github.event.inputs.releaseType == 'Prod' }}
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN_ML_WRAPPERS }}
+          packages_dir: python/dist/


### PR DESCRIPTION
This PR adds a github action workflow to release ml-wrappers package to pypi prod or test.  The workflow can be triggered from the github actions tab to release the package to pypi.  The file is similar to the release workflow files found in the https://github.com/microsoft/responsible-ai-toolbox/ repository.