### PR TITLE
fix error in ml-wrappers pypi release script

### DIFF
--- a/.github/workflows/release-ml-wrappers.yml
+++ b/.github/workflows/release-ml-wrappers.yml
@@ -73,8 +73,8 @@ jobs:
       - name: Upload a ml-wrappers build result
         uses: actions/upload-artifact@v2
         with:
-          name: ./python
-          path: ./python/dist/
+          name: ml_wrappers
+          path: python/dist/
 
       # publish to PyPI
       - name: Publish ml-wrappers package to Test PyPI


### PR DESCRIPTION
Fix error in name field of pypi release script:
Error: Artifact name is not valid: ./python. Contains the following character:  Forward slash /


Update:
link to passing upload to pypi test: https://github.com/microsoft/ml-wrappers/actions/runs/2470763658