### PR TITLE
Update requirements-dev.txt to pin transformers to less than 4.20.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,5 @@ lightgbm
 xgboost
 tensorflow
 shap
-transformers
+transformers==4.20.0
 datasets

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,5 @@ lightgbm
 xgboost
 tensorflow
 shap
-transformers==4.20.0
+transformers<4.20.0
 datasets


### PR DESCRIPTION
It seems like the recent with the recent release of transformers (4.20.X) the test `test_wrap_transformers_model` is broken with the following stack trace:-

```
=================================== FAILURES ===================================
______________ TestTextModelWrapper.test_wrap_transformers_model _______________
self = <test_text_model_wrapper.TestTextModelWrapper object at 0x7fd8a8535060>
    def test_wrap_transformers_model(self):
        emotion_data = load_emotion_dataset()
        docs = emotion_data[:10].drop(columns=EMOTION).values.tolist()
        pred = create_text_classification_pipeline()
        wrapped_model = wrap_model(pred, docs, ModelTask.TEXT_CLASSIFICATION)
>       validate_wrapped_classification_model(wrapped_model, docs)
/home/runner/work/ml-wrappers/ml-wrappers/tests/test_text_model_wrapper.py:24: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/home/runner/work/ml-wrappers/ml-wrappers/tests/wrapper_validator.py:18: in validate_wrapped_classification_model
    predictions = wrapped_model.predict(X_test)
/home/runner/work/ml-wrappers/ml-wrappers/python/ml_wrappers/model/text_model_wrapper.py:70: in predict
    pipeline_dicts = self._wrapped_model.inner_model(dataset)
/usr/share/miniconda/envs/test/lib/python3.10/site-packages/transformers/pipelines/text_classification.py:138: in __call__
    result = super().__call__(*args, **kwargs)
/usr/share/miniconda/envs/test/lib/python3.10/site-packages/transformers/pipelines/base.py:1032: in __call__
    outputs = [output for output in final_iterator]
/usr/share/miniconda/envs/test/lib/python3.10/site-packages/transformers/pipelines/base.py:1032: in <listcomp>
    outputs = [output for output in final_iterator]
/usr/share/miniconda/envs/test/lib/python3.10/site-packages/transformers/pipelines/pt_utils.py:111: in __next__
    item = next(self.iterator)
/usr/share/miniconda/envs/test/lib/python3.10/site-packages/transformers/pipelines/pt_utils.py:111: in __next__
    item = next(self.iterator)
/usr/share/miniconda/envs/test/lib/python3.10/site-packages/torch/utils/data/dataloader.py:652: in __next__
    data = self._next_data()
/usr/share/miniconda/envs/test/lib/python3.10/site-packages/torch/utils/data/dataloader.py:692: in _next_data
    data = self._dataset_fetcher.fetch(index)  # may raise StopIteration
/usr/share/miniconda/envs/test/lib/python3.10/site-packages/torch/utils/data/_utils/fetch.py:49: in fetch
    data = [self.dataset[idx] for idx in possibly_batched_index]
/usr/share/miniconda/envs/test/lib/python3.10/site-packages/torch/utils/data/_utils/fetch.py:49: in <listcomp>
    data = [self.dataset[idx] for idx in possibly_batched_index]
/usr/share/miniconda/envs/test/lib/python3.10/site-packages/transformers/pipelines/pt_utils.py:17: in __getitem__
    processed = self.process(item, **self.params)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
self = <transformers.pipelines.text_classification.TextClassificationPipeline object at 0x7fd894cebfa0>
inputs = ['i didnt feel humiliated'], tokenizer_kwargs = {}
return_tensors = 'pt'
    def preprocess(self, inputs, **tokenizer_kwargs) -> Dict[str, GenericTensor]:
        return_tensors = self.framework
        if isinstance(inputs, dict):
            return self.tokenizer(**inputs, return_tensors=return_tensors, **tokenizer_kwargs)
        elif isinstance(inputs, list) and len(inputs) == 1 and isinstance(inputs[0], list) and len(inputs[0]) == 2:
            # It used to be valid to use a list of list of list for text pairs, keeping this path for BC
            return self.tokenizer(
                text=inputs[0][0], text_pair=inputs[0][1], return_tensors=return_tensors, **tokenizer_kwargs
            )
        elif isinstance(inputs, list):
            # This is likely an invalid usage of the pipeline attempting to pass text pairs.
>           raise ValueError(
                "The pipeline received invalid inputs, if you are trying to send text pairs, you can try to send a"
                ' dictionnary `{"text": "My text", "text_pair": "My pair"}` in order to send a text pair.'
            )
E           ValueError: The pipeline received invalid inputs, if you are trying to send text pairs, you can try to send a dictionnary `{"text": "My text", "text_pair": "My pair"}` in order to send a text pair.
```

Looks like the transfomer code always expects a python dict and not a list. Not sure why the contract was broken in a minor release of transformers. The test works fine with 4.19.x version of transformers. Hence, pinning transformers to less than 4.20.0.