### PR TITLE
add catboost framework support to ml-wrappers

### DIFF
--- a/docs/WrapperSpecifications.md
+++ b/docs/WrapperSpecifications.md
@@ -2,19 +2,22 @@
 
 In the ML Wrappers SDK there needs to be a clear understanding of the model type to have a solid contract for users and visualizations.
 
-For example, in the machine learning interpretability space for blackbox models, this means that the user can pass in a function from a classifier or regressor, or a model that is a classifier or regressor. For model-specific explainers, the user would pass in the model directly. We can usually infer whether the model is a classifier or regressor in most cases.
+For example, in the machine learning interpretability space for blackbox models such as in the https://github.com/interpretml/interpret-community/ library, this means that the user can pass in a function from a classifier or regressor, or a model that is a classifier or regressor. For model-specific explainers, the user would pass in the model directly. We can usually infer whether the model is a classifier or regressor in most cases.
 
-- Functions - We can evaluate the function on the background data and look at the output to understand if the model is a classifier or regressor. In general, if the user passes a function that returns a 1D array, we can infer it is a regressor. If the function returns a 2D array, we can infer it is a classifier. There is a tricky case where the function may return a 2D array of 1 column. In this case, we can throw an exception and force the user to specify model_task=(infer, classifier, regressor), and not allow automatic inferencing. The user can override this behavior if they specify an optional parameter model_task=(infer, classifier, regressor), which will have the value model_task=infer by default.
+- Functions - We can evaluate the function on the data and look at the output to understand if the model is a classifier or regressor. In general, if the user passes a function that returns a 1D array, we can infer it is a regressor. If the function returns a 2D array, we can infer it is a classifier. There is a tricky case where the function may return a 2D array of 1 column. In this case, we can throw an exception and force the user to specify model_task=(infer, classifier, regressor), and not allow automatic inferencing. The user can override this behavior if they specify an optional parameter model_task=(infer, classifier, regressor), which will have the value model_task=infer by default.
+
   - If they specify model_task=infer:
     - We will try to infer whether the function is for classification or regression based on the specifications above.
   - If they specify model_task=classifier and:
-    - They have a 2D array - run explainer, treat output as classifier
-    - They have a 1D array - add wrapper function to convert output to 2D array. Run function on background samples and assert all values are probabilities. If are not all 1, convert to a 2D array with 2 columns [1-p, p]. If they are greater than 1, throw exception.
-    - They pass in classes parameter - run explainer, treat output as classifier
+    - They have a 2D array - run function, treat output as classifier
+    - They have a 1D array - add wrapper function to convert output to 2D array. Run function on samples and assert all values are probabilities. If are not all 1, convert to a 2D array with 2 columns [1-p, p]. If they are greater than 1, throw exception.
+    - They pass in classes parameter - run function, treat output as classifier
   - If they have model_task=regressor and:
     - They have a 2D array - if it has 1 column, treat it as regressor, if more than one column throw exception
-    - They have a 1D array - run explainer, treat output as regressor
+    - They have a 1D array - run function, treat output as regressor
     - They pass in a classes parameter - throw exception, since user specified they are not using a classifier
+
+Note for some types of frameworks, like catboost, we have found that the prediction results (in this case the predicted probabilities) for a single instance may be of a different shape than prediction results for multiple instances.  In this scenario, we can call the model for both single and multiple instances and compare the output dimensionality, and if they differ by one, wrap the prediction function to add an additional dimension if a single instance is predicted on.
 
 - Models - We can convert the model to a function and then use the specifications listed above. We convert the model to a function by either using the predict_proba function, or, if it is not available, the predict function. In some specific cases, we may be able to get additional information from the model to help us decide which function to use. Specifically, if we know that the model is a Keras model, the model will always have a predict_proba method available. In this case, we can look at the shape of predict_proba, and if it has multiple columns or is a single column with values outside the range of [0, 1], we can by default use predict instead. Otherwise, we can use predict_proba. If the user specified model_task=classifier, this will always override the behavior for Keras models and specify whether to use predict or predict_proba. Also, if the user specifies that model_task=classifier, but the model does not have a predict_proba function, we can wrap the function in a one-hot vector of probabilities. After the model is converted to a function that conforms to our specifications, we can wrap that in our model wrapper, which can contain a reference to the original model in cases where it may be needed or for debugging.
 
@@ -22,6 +25,7 @@ For example, in the machine learning interpretability space for blackbox models,
   - Scikit-Learn - This framework is directly supported by our APIs.
   - LightGBM - We can wrap the function into a scikit-learn compatible wrapper.
   - XGBoost - We can wrap the function into a scikit-learn compatible wrapper.
+  - Catboost - We can wrap the function into a scikit-learn compatible wrapper.
   - Keras with Tensorflow backend - Keras has both a predict_proba and predict function on all models, so it is difficult to know for sure if the model is a classifier or regressor. We can force the user to specify whether the model is a classifier or regressor in case only a single column is output, and then wrap the model in a model wrapper. If the user specifies the model is a regressor we can fix the structure to be 2D.
   - Pytorch - Pytorch does not have a predict or predict_proba function, but the model can be called on the dataset directly to get probabilities. The probabilities can then be transformed into predicted labels for classifiers. Similarly to Keras, we can force the user to specify whether the model is a classifier or regressor in case only a single column is output, and then wrap the model in a model wrapper. If the user specifies the model is a regressor we can fix the structure to be 2D.
   - ONNX - ONNX is not yet supported, but we plan to support it in the future. We can use a model wrapper to conform to the predict and predict_proba specifications the SDK requires.

--- a/python/ml_wrappers/model/function_wrapper.py
+++ b/python/ml_wrappers/model/function_wrapper.py
@@ -1,0 +1,144 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+"""Defines helper utilities for resolving prediction function shape inconsistencies."""
+
+import numpy as np
+
+from ..common.constants import ModelTask
+
+
+def _convert_to_two_cols(function, examples):
+    """In classification case, convert the function's output to two columns if it outputs one column.
+
+    :param function: The prediction function to evaluate on the examples.
+    :type function: function
+    :param examples: The model evaluation examples.
+    :type examples: numpy.ndarray or list
+    :return: The function chosen from given model and classification domain.
+    :rtype: (function, str)
+    """
+    # Add wrapper function to convert output to 2D array, check values to decide on whether
+    # to throw, or create two columns [1-p, p], or leave just one in multiclass one-class edge-case
+    result = function(examples)
+    # If the function gives a 2D array of one column, we will need to reshape it prior to concat
+    is_2d_result = len(result.shape) == 2
+    convert_to_two_cols = False
+    for value in result:
+        if value < 0 or value > 1:
+            raise Exception("Probability values outside of valid range: " + str(value))
+        if value < 1:
+            convert_to_two_cols = True
+    wrapper = _FunctionWrapper(function)
+    if convert_to_two_cols:
+        # Create two cols, [1-p, p], from evaluation result
+        if is_2d_result:
+            return (wrapper._function_2D_two_cols_wrapper_2D_result, ModelTask.CLASSIFICATION)
+        else:
+            return (wrapper._function_2D_two_cols_wrapper_1D_result, ModelTask.CLASSIFICATION)
+    else:
+        if is_2d_result:
+            return (function, ModelTask.CLASSIFICATION)
+        else:
+            return (wrapper._function_2D_one_col_wrapper, ModelTask.CLASSIFICATION)
+
+
+class _FunctionWrapper(object):
+    """Wraps a function to reshape the input and output data.
+
+    :param function: The prediction function to evaluate on the examples.
+    :type function: function
+    """
+
+    def __init__(self, function):
+        """Wraps a function to reshape the input and output data.
+
+        :param function: The prediction function to evaluate on the examples.
+        :type function: function
+        """
+        self._function = function
+
+    def _function_input_1D_wrapper(self, dataset):
+        """Wraps a function that reshapes the input dataset to be 2D from 1D.
+
+        :param dataset: The model evaluation examples.
+        :type dataset: numpy.ndarray
+        :return: A wrapped function.
+        :rtype: function
+        """
+        if len(dataset.shape) == 1:
+            dataset = dataset.reshape(1, -1)
+        return self._function(dataset)
+
+    def _function_flatten(self, dataset):
+        """Wraps a function that flattens the input dataset from 2D to 1D.
+
+        :param dataset: The model evaluation examples.
+        :type dataset: numpy.ndarray
+        :return: A wrapped function.
+        :rtype: function
+        """
+        return self._function(dataset).flatten()
+
+    def _function_2D_two_cols_wrapper_2D_result(self, dataset):
+        """Wraps a function that creates two columns, [1-p, p], from 2D array of one column evaluation result.
+
+        :param dataset: The model evaluation examples.
+        :type dataset: numpy.ndarray
+        :return: A wrapped function.
+        :rtype: function
+        """
+        result = self._function(dataset)[:, 0]
+        return np.stack([1 - result, result], axis=-1)
+
+    def _function_2D_two_cols_wrapper_1D_result(self, dataset):
+        """Wraps a function that creates two columns, [1-p, p], from evaluation result that is a 1D array.
+
+        :param dataset: The model evaluation examples.
+        :type dataset: numpy.ndarray
+        :return: A wrapped function.
+        :rtype: function
+        """
+        result = self._function(dataset)
+        return np.stack([1 - result, result], axis=-1)
+
+    def _function_2D_one_col_wrapper(self, dataset):
+        """Wraps a function that creates one column in rare edge case scenario for multiclass one-class result.
+
+        :param dataset: The model evaluation examples.
+        :type dataset: numpy.ndarray
+        :return: A wrapped function.
+        :rtype: function
+        """
+        result = self._function(dataset)
+        return result.reshape(result.shape[0], 1)
+
+
+class _MultiVsSingleInstanceFunctionResolver(object):
+    """Wraps function output to be same in single and multi-instance cases."""
+
+    def __init__(self, function):
+        """Wraps function output to be same in single and multi-instance cases
+
+        :param function: The prediction function to evaluate on the examples.
+        :type function: function
+        """
+        self._function = function
+
+    def _add_single_predict_dimension(self, dataset):
+        """Wraps function output for single instance case to add dimension.
+
+        Ensures the single instance case returns same dimensionality
+        as multi-instance prediction.
+
+        :param dataset: The model evaluation examples.
+        :type dataset: numpy.ndarray
+        :return: A wrapped function.
+        :rtype: function
+        """
+        result = self._function(dataset)
+        if len(dataset.shape) == 1:
+            return np.expand_dims(result, axis=0)
+        else:
+            return result

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 lightgbm
 xgboost
+catboost
 tensorflow
 shap
 transformers<4.20.0

--- a/tests/common_utils.py
+++ b/tests/common_utils.py
@@ -5,6 +5,7 @@
 # Defines common utilities for explanations
 import numpy as np
 import pandas as pd
+from catboost import CatBoostClassifier, CatBoostRegressor
 from sklearn import ensemble, linear_model, svm
 from sklearn.base import TransformerMixin
 from sklearn.datasets import (fetch_20newsgroups, fetch_california_housing,
@@ -157,6 +158,18 @@ def create_xgboost_classifier(X, y):
 def create_xgboost_regressor(X, y):
     xgb = XGBRegressor(learning_rate=0.1, max_depth=3, n_estimators=100,
                        n_jobs=1, random_state=777)
+    model = xgb.fit(X, y)
+    return model
+
+
+def create_catboost_classifier(X, y):
+    xgb = CatBoostClassifier(random_state=777, logging_level='Silent')
+    model = xgb.fit(X, y)
+    return model
+
+
+def create_catboost_regressor(X, y):
+    xgb = CatBoostRegressor(random_state=777, logging_level='Silent')
     model = xgb.fit(X, y)
     return model
 

--- a/tests/test_model_wrapper.py
+++ b/tests/test_model_wrapper.py
@@ -6,8 +6,9 @@
 
 import pandas as pd
 import pytest
-from common_utils import (create_keras_classifier, create_keras_regressor,
-                          create_lightgbm_classifier,
+from common_utils import (create_catboost_classifier,
+                          create_catboost_regressor, create_keras_classifier,
+                          create_keras_regressor, create_lightgbm_classifier,
                           create_lightgbm_regressor,
                           create_pytorch_multiclass_classifier,
                           create_pytorch_regressor,
@@ -56,6 +57,10 @@ class TestModelWrapper(object):
         train_classification_model_numpy(create_xgboost_classifier, iris)
         train_classification_model_pandas(create_xgboost_classifier, iris)
 
+    def test_wrap_catboost_classification_model(self, iris):
+        train_classification_model_numpy(create_catboost_classifier, iris)
+        train_classification_model_pandas(create_catboost_classifier, iris)
+
     def test_wrap_lightgbm_classification_model(self, iris):
         train_classification_model_numpy(create_lightgbm_classifier, iris)
         train_classification_model_pandas(create_lightgbm_classifier, iris)
@@ -87,6 +92,10 @@ class TestModelWrapper(object):
     def test_wrap_xgboost_regression_model(self, housing):
         train_regression_model_numpy(create_xgboost_regressor, housing)
         train_regression_model_pandas(create_xgboost_regressor, housing)
+
+    def test_wrap_catboost_regression_model(self, housing):
+        train_regression_model_numpy(create_catboost_regressor, housing)
+        train_regression_model_pandas(create_catboost_regressor, housing)
 
     def test_wrap_lightgbm_regression_model(self, housing):
         train_regression_model_numpy(create_lightgbm_regressor, housing)


### PR DESCRIPTION
Resolves issue:
https://github.com/microsoft/responsible-ai-toolbox/issues/1590

Currently catboost classifier and regressor are not supported by ml-wrappers.  This PR adds support for catboost framework.  Mainly, the current predict and predict_proba functions from catboost classifier fail to support scikit-learn specification due to two issues:
1.) Catboost predict_proba returns different results when either a single array is passed to the prediction function or multiple arrays are passed.  In the single instance case, catboost returns a single dimensional array of probabilities, whereas scikit-learn models always return a two-dimensional array of probabilities.
2.) Catboost predict function returns two dimensional array of one column, in the format [[1], [3], [2], [1]] etc, whereas scikit learn models return a one dimensional array on predict in the format [1, 3, 2, 1], etc.

For the first issue, we detect if the output dimensions are different in the single vs multi instance case - and if they differ by one, we add an extra dimension for the single instance prediction scenario.

For the second issue, a simple ravel() to one dimension resolves this inconsistency from catboost.