### PR TITLE
prevent build error via lower numpy version from conda to prevent re-install from pip

### DIFF
--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         packageDirectory: ["ml_wrappers"]
         operatingSystem: [ubuntu-latest, macos-latest, windows-latest]
-        pythonVersion: [3.6, 3.7, 3.8, 3.9, '3.10']
+        pythonVersion: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     runs-on: ${{ matrix.operatingSystem }}
 
@@ -27,6 +27,11 @@ jobs:
       shell: bash -l {0}
       run: |
         brew install libomp
+    - if: ${{ matrix.pythonVersion != '3.6' }}
+      name: Install numpy
+      shell: bash -l {0}
+      run: |
+        conda install --yes --quiet "numpy<=1.22.4" -c conda-forge
     - if: ${{ matrix.operatingSystem != 'macos-latest' }}
       name: Install pytorch on non-MacOS
       shell: bash -l {0}


### PR DESCRIPTION
Currently the gated build is failing on macos due to a lower numpy reinstall from pip (when package is already installed from conda).  I'm not sure which dependency this limit is coming from, pandas or scikit-learn, but it occurs during the editable install of ml-wrappers.  When re-installing numpy from pip, the incompatibilities cause unstable behavior which results in seg-fault errors when running tests in macos.
Note we don't use the bound for python 3.6, as it seems it then installs a too-new version of numpy, which causes an ancient version of pytorch to be installed for some reason.