### PR TITLE
add wrapper for fastai image multiclass classification models

### DIFF
--- a/python/ml_wrappers/model/image_model_wrapper.py
+++ b/python/ml_wrappers/model/image_model_wrapper.py
@@ -28,15 +28,18 @@ def _wrap_image_model(model, examples, model_task, is_function):
     """
     _wrapped_model = model
     if model_task == ModelTask.IMAGE_CLASSIFICATION:
-        _wrapped_model = WrappedImageClassificationModel(model)
+        if str(type(model)).endswith("fastai.learner.Learner'>"):
+            _wrapped_model = WrappedFastAIImageClassificationModel(model)
+        else:
+            _wrapped_model = WrappedTransformerImageClassificationModel(model)
     return _wrapped_model, model_task
 
 
-class WrappedImageClassificationModel(object):
+class WrappedTransformerImageClassificationModel(object):
     """A class for wrapping a Transformers model in the scikit-learn style."""
 
     def __init__(self, model):
-        """Initialize the WrappedImageClassificationModel."""
+        """Initialize the WrappedTransformerImageClassificationModel."""
         self._model = model
 
     def predict(self, dataset):
@@ -44,6 +47,8 @@ class WrappedImageClassificationModel(object):
 
         :param dataset: The dataset to predict on.
         :type dataset: ml_wrappers.DatasetWrapper
+        :return: The predicted values.
+        :rtype: numpy.ndarray
         """
         return np.argmax(self._model(dataset), axis=1)
 
@@ -52,5 +57,62 @@ class WrappedImageClassificationModel(object):
 
         :param dataset: The dataset to predict_proba on.
         :type dataset: ml_wrappers.DatasetWrapper
+        :return: The predicted probabilities.
+        :rtype: numpy.ndarray
         """
         return self._model(dataset)
+
+
+class WrappedFastAIImageClassificationModel(object):
+    """A class for wrapping a FastAI model in the scikit-learn style."""
+
+    def __init__(self, model):
+        """Initialize the WrappedFastAIImageClassificationModel."""
+        self._model = model
+
+    def _fastai_predict(self, dataset, index):
+        """Predict the output using the wrapped FastAI model.
+
+        :param dataset: The dataset to predict on.
+        :type dataset: ml_wrappers.DatasetWrapper
+        :param index: The index into the predicted data.
+            Index 1 is for the predicted class and index
+            2 is for the predicted probability.
+        :type index: int
+        :return: The predicted data.
+        :rtype: numpy.ndarray
+        """
+        # Note predict for single image requires 3d instead of 4d array
+        if len(dataset.shape) == 4:
+            predictions = []
+            for row in dataset:
+                predictions.append(self._fastai_predict(row, index))
+            predictions = np.array(predictions)
+            if index == 1:
+                predictions = predictions.flatten()
+            return predictions
+        else:
+            predictions = np.array(self._model.predict(dataset)[index])
+            if len(predictions.shape) == 0:
+                predictions = predictions.reshape(1)
+            return predictions
+
+    def predict(self, dataset):
+        """Predict the output value using the wrapped FastAI model.
+
+        :param dataset: The dataset to predict on.
+        :type dataset: ml_wrappers.DatasetWrapper
+        :return: The predicted values.
+        :rtype: numpy.ndarray
+        """
+        return self._fastai_predict(dataset, 1)
+
+    def predict_proba(self, dataset):
+        """Predict the output probability using the FastAI model.
+
+        :param dataset: The dataset to predict_proba on.
+        :type dataset: ml_wrappers.DatasetWrapper
+        :return: The predicted probabilities.
+        :rtype: numpy.ndarray
+        """
+        return self._fastai_predict(dataset, 2)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,5 @@ tensorflow
 shap
 transformers<4.20.0
 datasets
+raiutils
+fastai

--- a/tests/test_image_model_wrapper.py
+++ b/tests/test_image_model_wrapper.py
@@ -4,9 +4,12 @@
 
 """Tests for wrap_model function on vision-based models"""
 
+import sys
+
 import pytest
 from common_vision_utils import (create_image_classification_pipeline,
-                                 load_imagenet_dataset)
+                                 load_fridge_dataset, load_imagenet_dataset,
+                                 load_images, retrieve_or_train_fridge_model)
 from ml_wrappers import wrap_model
 from ml_wrappers.common.constants import ModelTask
 from wrapper_validator import validate_wrapped_classification_model
@@ -18,4 +21,20 @@ class TestImageModelWrapper(object):
         data = load_imagenet_dataset()
         pred = create_image_classification_pipeline()
         wrapped_model = wrap_model(pred, data, ModelTask.IMAGE_CLASSIFICATION)
+        validate_wrapped_classification_model(wrapped_model, data)
+
+    # Skip for older versions of python due to many breaking changes in fastai
+    @pytest.mark.skipif(sys.version_info.minor <= 6,
+                        reason='Fastai not supported for older versions')
+    def test_wrap_fastai_image_classification_model(self):
+        data = load_fridge_dataset()
+        try:
+            model = retrieve_or_train_fridge_model(data)
+        except Exception as e:
+            print("Failed to retrieve or load Fastai model, force training")
+            print("Inner exception message on retrieving model: {}".format(e))
+            model = retrieve_or_train_fridge_model(data, force_train=True)
+        # load the paths as numpy arrays
+        data = load_images(data)
+        wrapped_model = wrap_model(model, data, ModelTask.IMAGE_CLASSIFICATION)
         validate_wrapped_classification_model(wrapped_model, data)


### PR DESCRIPTION
Add a wrapper to support fastai vision learner models for multiclass classification.
Also adds a test case on a custom model for the image fridge classification dataset created at Microsoft Cambridge.