### PR TITLE
Update flake8 to 4.0.1 in requirements-linting.txt to fix flake8 gate

### DIFF
--- a/requirements-linting.txt
+++ b/requirements-linting.txt
@@ -1,4 +1,5 @@
 flake8==3.9.2
+
 flake8-bugbear==21.11.29
 flake8-blind-except==0.1.1
 flake8-breakpoint

--- a/requirements-linting.txt
+++ b/requirements-linting.txt
@@ -1,5 +1,4 @@
-flake8==3.9.2
-
+flake8==4.0.1
 flake8-bugbear==21.11.29
 flake8-blind-except==0.1.1
 flake8-breakpoint


### PR DESCRIPTION
The scheduled linting build failed with the following error trace:-

```
Run flake8 . --max-line-length=119 --count --max-complexity=20 --exclude=.git/,__pycache__/,dist/ --show-source --statistics
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.[7](https://github.com/microsoft/ml-wrappers/actions/runs/3174913342/jobs/5172303293#step:6:8).14/x64/bin/flake[8](https://github.com/microsoft/ml-wrappers/actions/runs/3174913342/jobs/5172303293#step:6:9)", line 8, in <module>
    sys.exit(main())
  File "/opt/hostedtoolcache/Python/3.7.[14](https://github.com/microsoft/ml-wrappers/actions/runs/3174913342/jobs/5172303293#step:6:15)/x64/lib/python3.7/site-packages/flake8/main/cli.py", line 22, in main
    app.run(argv)
  File "/opt/hostedtoolcache/Python/3.7.14/x64/lib/python3.7/site-packages/flake8/main/application.py", line 363, in run
    self._run(argv)
  File "/opt/hostedtoolcache/Python/3.7.14/x64/lib/python3.7/site-packages/flake8/main/application.py", line 350, in _run
    self.initialize(argv)
  File "/opt/hostedtoolcache/Python/3.7.14/x64/lib/python3.7/site-packages/flake8/main/application.py", line 330, in initialize
    self.find_plugins(config_finder)
  File "/opt/hostedtoolcache/Python/3.7.14/x64/lib/python3.7/site-packages/flake8/main/application.py", line [15](https://github.com/microsoft/ml-wrappers/actions/runs/3174913342/jobs/5172303293#step:6:16)3, in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
  File "/opt/hostedtoolcache/Python/3.7.14/x64/lib/python3.7/site-packages/flake8/plugins/manager.py", line 357, in __init__
    self.namespace, local_plugins=local_plugins
  File "/opt/hostedtoolcache/Python/3.7.14/x64/lib/python3.7/site-packages/flake8/plugins/manager.py", line [23](https://github.com/microsoft/ml-wrappers/actions/runs/3174913342/jobs/5172303293#step:6:24)8, in __init__
    self._load_entrypoint_plugins()
  File "/opt/hostedtoolcache/Python/3.7.14/x64/lib/python3.7/site-packages/flake8/plugins/manager.py", line [25](https://github.com/microsoft/ml-wrappers/actions/runs/3174913342/jobs/5172303293#step:6:26)4, in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
AttributeError: 'EntryPoints' object has no attribute 'get'
```

Upgrading flake8 to 4.0.1 fixes the issue.