### PR TITLE
Add model wrapper for wrapping data and predictions

### DIFF
--- a/python/ml_wrappers/model/predictions_wrapper.py
+++ b/python/ml_wrappers/model/predictions_wrapper.py
@@ -12,13 +12,13 @@ import pandas as pd
 TARGET = 'target'
 
 
-class ModelWrapperPredictions:
+class PredictionsModelWrapper:
     """Model wrapper to wrap the samples used to train the models
     and the predictions of the model. This wrapper is useful when
     it is not possible to load the model.
     """
     def __init__(self, test_data: pd.DataFrame, y_pred: np.ndarray):
-        """Creates an ModelWrapper object.
+        """Creates a PredictionsModelWrapper object.
 
         :param test_data: The data that was used to train the model.
         :type test_data: pd.DataFrame
@@ -85,41 +85,49 @@ class ModelWrapperPredictions:
         return np.array(prediction_output)
 
     def __setstate__(self, state):
-        """Set the state so that the wrapped model is
-        serializable via pickle."""
+        """Set the state of the class object so that the wrapped
+        model is serializable via pickle.
+
+        :param state: A dictionary of deserialized state.
+        :type state: Dict
+        """
         self._combined_data = state["_combined_data"]
 
     def __getstate__(self):
         """Return the state so that the wrapped model is
-        serializable via pickle."""
+        serializable via pickle.
+
+        :return: The state to be pickled.
+        :rtype: Dict
+        """
         state = {}
         state["_combined_data"] = self._combined_data
         return state
 
 
-class ModelWrapperPredictionsRegression(ModelWrapperPredictions):
+class PredictionsModelWrapperRegression(PredictionsModelWrapper):
     """Model wrapper to wrap the samples used to train the models
     and the predictions of the model for regression tasks.
     """
     def __init__(self, test_data: pd.DataFrame, y_pred: np.ndarray):
-        """Creates an ModelWrapperPredictionsRegression object.
+        """Creates a PredictionsModelWrapperRegression object.
 
         :param test_data: The data that was used to train the model.
         :type test_data: pd.DataFrame
         :param y_pred: Predictions of the model.
         :type y_pred: np.ndarray
         """
-        super(ModelWrapperPredictionsRegression, self).__init__(
+        super(PredictionsModelWrapperRegression, self).__init__(
             test_data, y_pred)
 
 
-class ModelWrapperPredictionsClassification(ModelWrapperPredictions):
+class PredictionsModelWrapperClassification(PredictionsModelWrapper):
     """Model wrapper to wrap the samples used to train the models
     and the predictions of the model for classification tasks.
     """
     def __init__(self, test_data: pd.DataFrame, y_pred: np.ndarray,
                  y_pred_proba: Optional[np.ndarray] = None):
-        """Creates an ModelWrapperPredictionsClassification object.
+        """Creates a PredictionsModelWrapperClassification object.
 
         :param test_data: The data that was used to train the model.
         :type test_data: pd.DataFrame
@@ -128,7 +136,7 @@ class ModelWrapperPredictionsClassification(ModelWrapperPredictions):
         :param y_pred_proba: Prediction probabilities of the model.
         :type y_pred_proba: np.ndarray
         """
-        super(ModelWrapperPredictionsClassification, self).__init__(
+        super(PredictionsModelWrapperClassification, self).__init__(
             test_data, y_pred)
         self._num_classes = None
         if y_pred_proba is not None:
@@ -168,14 +176,22 @@ class ModelWrapperPredictionsClassification(ModelWrapperPredictions):
         return np.array(prediction_output)
 
     def __setstate__(self, state):
-        """Set the state so that the wrapped model is
-        serializable via pickle."""
+        """Set the state of the class object so that the wrapped
+        model is serializable via pickle.
+
+        :param state: A dictionary of deserialized state.
+        :type state: Dict
+        """
         super().__setstate__(state)
         self._num_classes = state["_num_classes"]
 
     def __getstate__(self):
         """Return the state so that the wrapped model is
-        serializable via pickle."""
+        serializable via pickle.
+
+        :return: The state to be pickled.
+        :rtype: Dict
+        """
         state = super().__getstate__()
         state["_num_classes"] = self._num_classes
         return state

--- a/python/ml_wrappers/model/predictions_wrapper.py
+++ b/python/ml_wrappers/model/predictions_wrapper.py
@@ -1,0 +1,196 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+"""Defines classes to wrap the training/test data and the corresponding predictions from the model."""
+
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+TARGET = 'target'
+
+
+class ModelWrapperPredictions:
+    """Model wrapper to wrap the samples used to train the models
+    and the predictions of the model. This wrapper is useful when
+    it is not possible to load the model.
+    """
+    def __init__(self, test_data: pd.DataFrame, y_pred: np.ndarray):
+        """Creates an ModelWrapper object.
+
+        :param test_data: The data that was used to train the model.
+        :type test_data: pd.DataFrame
+        :param y_pred: Predictions of the model.
+        :type y_pred: np.ndarray
+        """
+        if not isinstance(test_data, pd.DataFrame):
+            raise ConfigValidationException(
+                "Expecting a pandas dataframe for test_data")
+        if not isinstance(y_pred, np.ndarray):
+            raise ConfigValidationException(
+                "Expecting a numpy array for y_pred")
+        if len(test_data) != len(y_pred):
+            raise ConfigValidationException(
+                "The number of instances in test data "
+                "do not match with number of predictions")
+        self._combined_data = test_data.copy()
+        self._combined_data[TARGET] = y_pred
+
+    def _get_filtered_data(
+            self, query_test_data_row: pd.Series) -> pd.DataFrame:
+        """Return the filtered data based on the query data.
+
+        :param query_test_data_row: The query data instance.
+        :type query_test_data_row: pd.Series
+        :return: The filtered dataframe based on the values in query data.
+        :rtype: pd.DataFrame
+        """
+        queries = []
+        for column_name, column_data in query_test_data_row.iteritems():
+            if isinstance(column_data, str):
+                queries.append("`{}` == '{}'".format(
+                    column_name, column_data))
+            else:
+                queries.append("`{}` == {}".format(
+                    column_name, column_data))
+
+        queries_str = '(' + ') & ('.join(queries) + ')'
+        filtered_df = self._combined_data.query(queries_str)
+
+        if len(filtered_df) == 0:
+            raise EmptyDataFrameException(
+                "The query data was not found in the combined dataset")
+
+        return filtered_df
+
+    def predict(self, query_test_data: pd.DataFrame) -> np.ndarray:
+        """Return the predictions based on the query data.
+
+        :param query_test_data: The data for which the predictions need to
+            be returned.
+        :type query_test_data: pd.DataFrame
+        :return: Predictions of the model.
+        :rtype: np.ndarray
+        """
+        if not isinstance(query_test_data, pd.DataFrame):
+            raise Exception("Expecting a pandas dataframe for query_test_data")
+        prediction_output = []
+        for _, row in query_test_data.iterrows():
+            filtered_df = self._get_filtered_data(row)
+            prediction_output.append(filtered_df[TARGET].values[0])
+
+        return np.array(prediction_output)
+
+    def __setstate__(self, state):
+        """Set the state so that the wrapped model is
+        serializable via pickle."""
+        self._combined_data = state["_combined_data"]
+
+    def __getstate__(self):
+        """Return the state so that the wrapped model is
+        serializable via pickle."""
+        state = {}
+        state["_combined_data"] = self._combined_data
+        return state
+
+
+class ModelWrapperPredictionsRegression(ModelWrapperPredictions):
+    """Model wrapper to wrap the samples used to train the models
+    and the predictions of the model for regression tasks.
+    """
+    def __init__(self, test_data: pd.DataFrame, y_pred: np.ndarray):
+        """Creates an ModelWrapperPredictionsRegression object.
+
+        :param test_data: The data that was used to train the model.
+        :type test_data: pd.DataFrame
+        :param y_pred: Predictions of the model.
+        :type y_pred: np.ndarray
+        """
+        super(ModelWrapperPredictionsRegression, self).__init__(
+            test_data, y_pred)
+
+
+class ModelWrapperPredictionsClassification(ModelWrapperPredictions):
+    """Model wrapper to wrap the samples used to train the models
+    and the predictions of the model for classification tasks.
+    """
+    def __init__(self, test_data: pd.DataFrame, y_pred: np.ndarray,
+                 y_pred_proba: Optional[np.ndarray] = None):
+        """Creates an ModelWrapperPredictionsClassification object.
+
+        :param test_data: The data that was used to train the model.
+        :type test_data: pd.DataFrame
+        :param y_pred: Predictions of the model.
+        :type y_pred: np.ndarray
+        :param y_pred_proba: Prediction probabilities of the model.
+        :type y_pred_proba: np.ndarray
+        """
+        super(ModelWrapperPredictionsClassification, self).__init__(
+            test_data, y_pred)
+        self._num_classes = None
+        if y_pred_proba is not None:
+            for i in range(0, len(y_pred_proba[0])):
+                self._combined_data[
+                    TARGET + '_' + str(i)] = y_pred_proba[:, i]
+            self._num_classes = len(y_pred_proba[0])
+
+    def predict_proba(self, query_test_data: pd.DataFrame) -> np.ndarray:
+        """Return the prediction probabilities based on the query data.
+
+        :param query_test_data: The data for which the prediction
+            probabilities need to be returned.
+        :type query_test_data: pd.DataFrame
+        :return: Prediction probabilities of the model.
+        :rtype: np.ndarray
+        """
+        if not isinstance(query_test_data, pd.DataFrame):
+            raise ConfigValidationException(
+                "Expecting a pandas dataframe for query_test_data")
+        if self._num_classes is None:
+            raise ConfigValidationException(
+                "Model wrapper configured without prediction probabilities"
+            )
+        prediction_output = []
+        for _, row in query_test_data.iterrows():
+            filtered_df = self._get_filtered_data(row)
+            classes_output = []
+            for i in range(self._num_classes):
+                classes_output.append(
+                    filtered_df[TARGET + '_' + str(i)].values[0])
+            prediction_output.append(classes_output)
+
+        return np.array(prediction_output)
+
+    def __setstate__(self, state):
+        """Set the state so that the wrapped model is
+        serializable via pickle."""
+        super().__setstate__(state)
+        self._num_classes = state["_num_classes"]
+
+    def __getstate__(self):
+        """Return the state so that the wrapped model is
+        serializable via pickle."""
+        state = super().__getstate__()
+        state["_num_classes"] = self._num_classes
+        return state
+
+
+class EmptyDataFrameException(Exception):
+    """An exception indicating that some an empty dataframe
+    is being used for prediction.
+
+    :param exception_message: A message describing the error.
+    :type exception_message: str
+    """
+    _error_code = 'Empty data exception'
+
+
+class ConfigValidationException(Exception):
+    """An exception indicating that some user configuration is not valid.
+
+    :param exception_message: A message describing the error.
+    :type exception_message: str
+    """
+    _error_code = 'Invalid config'

--- a/python/ml_wrappers/model/predictions_wrapper.py
+++ b/python/ml_wrappers/model/predictions_wrapper.py
@@ -26,13 +26,13 @@ class ModelWrapperPredictions:
         :type y_pred: np.ndarray
         """
         if not isinstance(test_data, pd.DataFrame):
-            raise ConfigValidationException(
+            raise DataValidationException(
                 "Expecting a pandas dataframe for test_data")
         if not isinstance(y_pred, np.ndarray):
-            raise ConfigValidationException(
+            raise DataValidationException(
                 "Expecting a numpy array for y_pred")
         if len(test_data) != len(y_pred):
-            raise ConfigValidationException(
+            raise DataValidationException(
                 "The number of instances in test data "
                 "do not match with number of predictions")
         self._combined_data = test_data.copy()
@@ -60,7 +60,7 @@ class ModelWrapperPredictions:
         filtered_df = self._combined_data.query(queries_str)
 
         if len(filtered_df) == 0:
-            raise EmptyDataFrameException(
+            raise EmptyDataException(
                 "The query data was not found in the combined dataset")
 
         return filtered_df
@@ -75,7 +75,8 @@ class ModelWrapperPredictions:
         :rtype: np.ndarray
         """
         if not isinstance(query_test_data, pd.DataFrame):
-            raise Exception("Expecting a pandas dataframe for query_test_data")
+            raise DataValidationException(
+                "Expecting a pandas dataframe for query_test_data")
         prediction_output = []
         for _, row in query_test_data.iterrows():
             filtered_df = self._get_filtered_data(row)
@@ -131,6 +132,9 @@ class ModelWrapperPredictionsClassification(ModelWrapperPredictions):
             test_data, y_pred)
         self._num_classes = None
         if y_pred_proba is not None:
+            if not isinstance(y_pred_proba, np.ndarray):
+                raise DataValidationException(
+                    "Expecting a numpy array for y_pred_proba")
             for i in range(0, len(y_pred_proba[0])):
                 self._combined_data[
                     TARGET + '_' + str(i)] = y_pred_proba[:, i]
@@ -146,10 +150,10 @@ class ModelWrapperPredictionsClassification(ModelWrapperPredictions):
         :rtype: np.ndarray
         """
         if not isinstance(query_test_data, pd.DataFrame):
-            raise ConfigValidationException(
+            raise DataValidationException(
                 "Expecting a pandas dataframe for query_test_data")
         if self._num_classes is None:
-            raise ConfigValidationException(
+            raise DataValidationException(
                 "Model wrapper configured without prediction probabilities"
             )
         prediction_output = []
@@ -177,9 +181,8 @@ class ModelWrapperPredictionsClassification(ModelWrapperPredictions):
         return state
 
 
-class EmptyDataFrameException(Exception):
-    """An exception indicating that some an empty dataframe
-    is being used for prediction.
+class EmptyDataException(Exception):
+    """An exception indicating that some operation produced empty data.
 
     :param exception_message: A message describing the error.
     :type exception_message: str
@@ -187,10 +190,10 @@ class EmptyDataFrameException(Exception):
     _error_code = 'Empty data exception'
 
 
-class ConfigValidationException(Exception):
-    """An exception indicating that some user configuration is not valid.
+class DataValidationException(Exception):
+    """An exception indicating that some user supplied data is not valid.
 
     :param exception_message: A message describing the error.
     :type exception_message: str
     """
-    _error_code = 'Invalid config'
+    _error_code = 'Invalid data'

--- a/tests/test_predictions_wrapper.py
+++ b/tests/test_predictions_wrapper.py
@@ -4,11 +4,15 @@
 
 """Tests for predictions model wrapper."""
 
+import pickle
+
 import numpy as np
 import pandas as pd
+import pytest
 from common_utils import create_lightgbm_classifier, create_lightgbm_regressor
 from constants import DatasetConstants
 from ml_wrappers.model.predictions_wrapper import (
+    DataValidationException, EmptyDataException,
     ModelWrapperPredictionsClassification, ModelWrapperPredictionsRegression)
 
 
@@ -23,6 +27,12 @@ class TestPredictionsWrapper:
         model_predict_proba_output = model.predict_proba(test_data)
         model_wrapper_predict_proba_output = model_wrapper.predict_proba(test_data)
         np.all(model_predict_proba_output == model_wrapper_predict_proba_output)
+
+    def verify_pickle_serialization(self, model, model_wrapper, test_data):
+        new_model_wrapper = pickle.loads(pickle.dumps(model_wrapper))
+        self.verify_predict_outputs(model, new_model_wrapper, test_data)
+        if hasattr(new_model_wrapper, "predict_proba"):
+            self.verify_predict_proba_outputs(model, new_model_wrapper, test_data)
 
     def test_prediction_wrapper_classification(self, iris):
         dataset = iris
@@ -41,6 +51,7 @@ class TestPredictionsWrapper:
 
         self.verify_predict_outputs(model, model_wrapper, X_test)
         self.verify_predict_proba_outputs(model, model_wrapper, X_test)
+        self.verify_pickle_serialization(model, model_wrapper, X_test)
 
     def test_prediction_wrapper_regression(self, housing):
         dataset = housing
@@ -57,3 +68,101 @@ class TestPredictionsWrapper:
             X_test, model_predict)
 
         self.verify_predict_outputs(model, model_wrapper, X_test)
+        assert not hasattr(model_wrapper, "predict_proba")
+        self.verify_pickle_serialization(model, model_wrapper, X_test)
+
+    def test_prediction_wrapper_unsupported_scenarios(self, iris):
+        dataset = iris
+        X_train = pd.DataFrame(data=dataset[DatasetConstants.X_TRAIN],
+                               columns=dataset[DatasetConstants.FEATURES])
+        X_test = pd.DataFrame(data=dataset[DatasetConstants.X_TEST],
+                              columns=dataset[DatasetConstants.FEATURES])
+        y_train = dataset[DatasetConstants.Y_TRAIN]
+        model = create_lightgbm_classifier(X_train, y_train)
+
+        model_predict = model.predict(X_test)
+        model_predict_proba = model.predict_proba(X_test)
+
+        with pytest.raises(
+                DataValidationException,
+                match="Expecting a pandas dataframe for test_data"):
+            ModelWrapperPredictionsClassification(
+                X_test.values, model_predict, model_predict_proba
+            )
+
+        with pytest.raises(
+                DataValidationException,
+                match="Expecting a numpy array for y_pred"):
+            ModelWrapperPredictionsClassification(
+                X_test, model_predict.tolist(), model_predict_proba
+            )
+
+        with pytest.raises(
+                DataValidationException,
+                match="Expecting a numpy array for y_pred_proba"):
+            ModelWrapperPredictionsClassification(
+                X_test, model_predict, model_predict_proba.tolist()
+            )
+
+        with pytest.raises(
+                DataValidationException,
+                match="The number of instances in test data "
+                      "do not match with number of predictions"):
+            ModelWrapperPredictionsClassification(
+                X_test.iloc[0:len(X_test) - 1], model_predict, model_predict_proba
+            )
+
+    def test_prediction_wrapper_unsupported_predict_scenarios(self, iris):
+        dataset = iris
+        X_train = pd.DataFrame(data=dataset[DatasetConstants.X_TRAIN],
+                               columns=dataset[DatasetConstants.FEATURES])
+        X_test = pd.DataFrame(data=dataset[DatasetConstants.X_TEST],
+                              columns=dataset[DatasetConstants.FEATURES])
+        y_train = dataset[DatasetConstants.Y_TRAIN]
+        model = create_lightgbm_classifier(X_train, y_train)
+
+        model_predict = model.predict(X_test)
+        model_predict_proba = model.predict_proba(X_test)
+
+        model_wrapper = ModelWrapperPredictionsClassification(
+            X_test, model_predict, model_predict_proba)
+        with pytest.raises(
+                DataValidationException,
+                match="Expecting a pandas dataframe for query_test_data"):
+            model_wrapper.predict(X_test.values)
+        with pytest.raises(
+                DataValidationException,
+                match="Expecting a pandas dataframe for query_test_data"):
+            model_wrapper.predict_proba(X_test.values)
+
+        model_wrapper_without_predict_proba = \
+            ModelWrapperPredictionsClassification(X_test, model_predict)
+        with pytest.raises(
+                DataValidationException,
+                match="Model wrapper configured without prediction probabilities"):
+            model_wrapper_without_predict_proba.predict_proba(X_test)
+
+    def test_prediction_wrapper_unseen_data_predict_scenarios(self, iris):
+        dataset = iris
+        X_train = pd.DataFrame(data=dataset[DatasetConstants.X_TRAIN],
+                               columns=dataset[DatasetConstants.FEATURES])
+        X_test = pd.DataFrame(data=dataset[DatasetConstants.X_TEST],
+                              columns=dataset[DatasetConstants.FEATURES])
+        y_train = dataset[DatasetConstants.Y_TRAIN]
+        model = create_lightgbm_classifier(X_train, y_train)
+
+        model_predict = model.predict(X_test[0:len(X_test) - 1])
+        model_predict_proba = model.predict_proba(X_test[0:len(X_test) - 1])
+
+        model_wrapper = ModelWrapperPredictionsClassification(
+            X_test[0:len(X_test) - 1], model_predict, model_predict_proba)
+
+        with pytest.raises(
+                EmptyDataException,
+                match="The query data was not found in the combined dataset"):
+            model_wrapper.predict(X_test[len(X_test) - 1:len(X_test)])
+
+        with pytest.raises(
+                EmptyDataException,
+                match="The query data was not found in the combined dataset"):
+            model_wrapper.predict_proba(X_test[len(X_test) - 1:len(X_test)])

--- a/tests/test_predictions_wrapper.py
+++ b/tests/test_predictions_wrapper.py
@@ -1,0 +1,59 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+"""Tests for predictions model wrapper."""
+
+import numpy as np
+import pandas as pd
+from common_utils import create_lightgbm_classifier, create_lightgbm_regressor
+from constants import DatasetConstants
+from ml_wrappers.model.predictions_wrapper import (
+    ModelWrapperPredictionsClassification, ModelWrapperPredictionsRegression)
+
+
+class TestPredictionsWrapper:
+
+    def verify_predict_outputs(self, model, model_wrapper, test_data):
+        model_predict_output = model.predict(test_data)
+        model_wrapper_predict_output = model_wrapper.predict(test_data)
+        np.all(model_predict_output == model_wrapper_predict_output)
+
+    def verify_predict_proba_outputs(self, model, model_wrapper, test_data):
+        model_predict_proba_output = model.predict_proba(test_data)
+        model_wrapper_predict_proba_output = model_wrapper.predict_proba(test_data)
+        np.all(model_predict_proba_output == model_wrapper_predict_proba_output)
+
+    def test_prediction_wrapper_classification(self, iris):
+        dataset = iris
+        X_train = pd.DataFrame(data=dataset[DatasetConstants.X_TRAIN],
+                               columns=dataset[DatasetConstants.FEATURES])
+        X_test = pd.DataFrame(data=dataset[DatasetConstants.X_TEST],
+                              columns=dataset[DatasetConstants.FEATURES])
+        y_train = dataset[DatasetConstants.Y_TRAIN]
+        model = create_lightgbm_classifier(X_train, y_train)
+
+        model_predict = model.predict(X_test)
+        model_predict_proba = model.predict_proba(X_test)
+
+        model_wrapper = ModelWrapperPredictionsClassification(
+            X_test, model_predict, model_predict_proba)
+
+        self.verify_predict_outputs(model, model_wrapper, X_test)
+        self.verify_predict_proba_outputs(model, model_wrapper, X_test)
+
+    def test_prediction_wrapper_regression(self, housing):
+        dataset = housing
+        X_train = pd.DataFrame(data=dataset[DatasetConstants.X_TRAIN],
+                               columns=dataset[DatasetConstants.FEATURES])
+        X_test = pd.DataFrame(data=dataset[DatasetConstants.X_TEST],
+                              columns=dataset[DatasetConstants.FEATURES])
+        y_train = dataset[DatasetConstants.Y_TRAIN]
+        model = create_lightgbm_regressor(X_train, y_train)
+
+        model_predict = model.predict(X_test)
+
+        model_wrapper = ModelWrapperPredictionsRegression(
+            X_test, model_predict)
+
+        self.verify_predict_outputs(model, model_wrapper, X_test)

--- a/tests/test_predictions_wrapper.py
+++ b/tests/test_predictions_wrapper.py
@@ -13,7 +13,7 @@ from common_utils import create_lightgbm_classifier, create_lightgbm_regressor
 from constants import DatasetConstants
 from ml_wrappers.model.predictions_wrapper import (
     DataValidationException, EmptyDataException,
-    ModelWrapperPredictionsClassification, ModelWrapperPredictionsRegression)
+    PredictionsModelWrapperClassification, PredictionsModelWrapperRegression)
 
 
 class TestPredictionsWrapper:
@@ -46,7 +46,7 @@ class TestPredictionsWrapper:
         model_predict = model.predict(X_test)
         model_predict_proba = model.predict_proba(X_test)
 
-        model_wrapper = ModelWrapperPredictionsClassification(
+        model_wrapper = PredictionsModelWrapperClassification(
             X_test, model_predict, model_predict_proba)
 
         self.verify_predict_outputs(model, model_wrapper, X_test)
@@ -64,7 +64,7 @@ class TestPredictionsWrapper:
 
         model_predict = model.predict(X_test)
 
-        model_wrapper = ModelWrapperPredictionsRegression(
+        model_wrapper = PredictionsModelWrapperRegression(
             X_test, model_predict)
 
         self.verify_predict_outputs(model, model_wrapper, X_test)
@@ -86,21 +86,21 @@ class TestPredictionsWrapper:
         with pytest.raises(
                 DataValidationException,
                 match="Expecting a pandas dataframe for test_data"):
-            ModelWrapperPredictionsClassification(
+            PredictionsModelWrapperClassification(
                 X_test.values, model_predict, model_predict_proba
             )
 
         with pytest.raises(
                 DataValidationException,
                 match="Expecting a numpy array for y_pred"):
-            ModelWrapperPredictionsClassification(
+            PredictionsModelWrapperClassification(
                 X_test, model_predict.tolist(), model_predict_proba
             )
 
         with pytest.raises(
                 DataValidationException,
                 match="Expecting a numpy array for y_pred_proba"):
-            ModelWrapperPredictionsClassification(
+            PredictionsModelWrapperClassification(
                 X_test, model_predict, model_predict_proba.tolist()
             )
 
@@ -108,7 +108,7 @@ class TestPredictionsWrapper:
                 DataValidationException,
                 match="The number of instances in test data "
                       "do not match with number of predictions"):
-            ModelWrapperPredictionsClassification(
+            PredictionsModelWrapperClassification(
                 X_test.iloc[0:len(X_test) - 1], model_predict, model_predict_proba
             )
 
@@ -124,7 +124,7 @@ class TestPredictionsWrapper:
         model_predict = model.predict(X_test)
         model_predict_proba = model.predict_proba(X_test)
 
-        model_wrapper = ModelWrapperPredictionsClassification(
+        model_wrapper = PredictionsModelWrapperClassification(
             X_test, model_predict, model_predict_proba)
         with pytest.raises(
                 DataValidationException,
@@ -136,7 +136,7 @@ class TestPredictionsWrapper:
             model_wrapper.predict_proba(X_test.values)
 
         model_wrapper_without_predict_proba = \
-            ModelWrapperPredictionsClassification(X_test, model_predict)
+            PredictionsModelWrapperClassification(X_test, model_predict)
         with pytest.raises(
                 DataValidationException,
                 match="Model wrapper configured without prediction probabilities"):
@@ -154,7 +154,7 @@ class TestPredictionsWrapper:
         model_predict = model.predict(X_test[0:len(X_test) - 1])
         model_predict_proba = model.predict_proba(X_test[0:len(X_test) - 1])
 
-        model_wrapper = ModelWrapperPredictionsClassification(
+        model_wrapper = PredictionsModelWrapperClassification(
             X_test[0:len(X_test) - 1], model_predict, model_predict_proba)
 
         with pytest.raises(


### PR DESCRIPTION
The model wrapper base class `ModelWrapperPredictions` wraps the test data and model prediction and supports the predict call. The `ModelWrapperPredictionsClassification` also supports the `predict_proba` method.

Signed-off-by: Gaurav Gupta <gaugup@microsoft.com>