### PR TITLE
Add titanic dataset to prediction model wrapper tests

### DIFF
--- a/tests/common_utils.py
+++ b/tests/common_utils.py
@@ -6,15 +6,19 @@
 import numpy as np
 import pandas as pd
 from catboost import CatBoostClassifier, CatBoostRegressor
-from sklearn import ensemble, linear_model, svm
+from sklearn import linear_model, svm
 from sklearn.base import TransformerMixin
+from sklearn.compose import ColumnTransformer
 from sklearn.datasets import (fetch_20newsgroups, fetch_california_housing,
                               load_breast_cancer, load_iris)
-from sklearn.ensemble import RandomForestClassifier
+from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from sklearn.feature_extraction.text import CountVectorizer, TfidfVectorizer
+from sklearn.impute import SimpleImputer
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.model_selection import train_test_split
 from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import (FunctionTransformer, OneHotEncoder,
+                                   StandardScaler)
 
 try:
     from lightgbm import LGBMClassifier, LGBMRegressor
@@ -129,7 +133,7 @@ def create_linear_vectorizer():
 
 
 def create_sklearn_random_forest_classifier(X, y):
-    rfc = ensemble.RandomForestClassifier(n_estimators=10, max_depth=4, random_state=777)
+    rfc = RandomForestClassifier(n_estimators=10, max_depth=4, random_state=777)
     model = rfc.fit(X, y)
     return model
 
@@ -214,7 +218,7 @@ def create_pandas_only_svm_classifier(X, y, probability=True):
 
 
 def create_sklearn_random_forest_regressor(X, y):
-    rfr = ensemble.RandomForestRegressor(n_estimators=10, max_depth=4, random_state=777)
+    rfr = RandomForestRegressor(n_estimators=10, max_depth=4, random_state=777)
     model = rfr.fit(X, y)
     return model
 
@@ -496,6 +500,39 @@ def create_pytorch_multiclass_classifier(X, y):
     criterion = nn.CrossEntropyLoss()
     optimizer = torch.optim.SGD(net.parameters(), lr=0.01)
     return _train_pytorch_model(epochs, criterion, optimizer, net, torch_X, torch_y)
+
+
+def create_titanic_pipeline(X_train, y_train):
+    def conv(X):
+        if isinstance(X, pd.Series):
+            return X.values
+        return X
+
+    many_to_one_transformer = \
+        FunctionTransformer(lambda x: conv(x.sum(axis=1)).reshape(-1, 1))
+    many_to_many_transformer = \
+        FunctionTransformer(lambda x: np.hstack(
+            (conv(np.prod(x, axis=1)).reshape(-1, 1),
+                conv(np.prod(x, axis=1)**2).reshape(-1, 1))
+        ))
+    transformations = ColumnTransformer([
+        ("age_fare_1", Pipeline(steps=[
+            ('imputer', SimpleImputer(strategy='median')),
+            ('scaler', StandardScaler())
+        ]), ["age", "fare"]),
+        ("age_fare_2", many_to_one_transformer, ["age", "fare"]),
+        ("age_fare_3", many_to_many_transformer, ["age", "fare"]),
+        ("embarked", Pipeline(steps=[
+            ("imputer",
+                SimpleImputer(strategy='constant', fill_value='missing')),
+            ("encoder", OneHotEncoder(sparse=False))]), ["embarked"]),
+        ("sex_pclass", OneHotEncoder(sparse=False), ["sex", "pclass"])
+    ])
+    clf = Pipeline(steps=[('preprocessor', transformations),
+                          ('classifier',
+                           LogisticRegression(solver='lbfgs'))])
+    clf.fit(X_train, y_train)
+    return clf
 
 
 def create_dnn_classifier_unfit(feature_number):

--- a/tests/test_predictions_wrapper.py
+++ b/tests/test_predictions_wrapper.py
@@ -9,7 +9,8 @@ import pickle
 import numpy as np
 import pandas as pd
 import pytest
-from common_utils import create_lightgbm_classifier, create_lightgbm_regressor
+from common_utils import (create_lightgbm_classifier,
+                          create_lightgbm_regressor, create_titanic_pipeline)
 from constants import DatasetConstants
 from ml_wrappers.model.predictions_wrapper import (
     DataValidationException, EmptyDataException,
@@ -34,14 +35,28 @@ class TestPredictionsWrapper:
         if hasattr(new_model_wrapper, "predict_proba"):
             self.verify_predict_proba_outputs(model, new_model_wrapper, test_data)
 
-    def test_prediction_wrapper_classification(self, iris):
-        dataset = iris
-        X_train = pd.DataFrame(data=dataset[DatasetConstants.X_TRAIN],
-                               columns=dataset[DatasetConstants.FEATURES])
-        X_test = pd.DataFrame(data=dataset[DatasetConstants.X_TEST],
-                              columns=dataset[DatasetConstants.FEATURES])
+
+class TestPredictionsWrapperClassification(TestPredictionsWrapper):
+    @pytest.mark.parametrize('dataset_name', ['iris', 'titanic'])
+    def test_prediction_wrapper_classification(self, iris, titanic_simple, dataset_name):
+        if dataset_name == 'iris':
+            dataset = iris
+            X_train = pd.DataFrame(data=dataset[DatasetConstants.X_TRAIN],
+                                   columns=dataset[DatasetConstants.FEATURES])
+            X_test = pd.DataFrame(data=dataset[DatasetConstants.X_TEST],
+                                  columns=dataset[DatasetConstants.FEATURES])
+        else:
+            dataset = titanic_simple
+            X_train = pd.DataFrame(data=dataset[DatasetConstants.X_TRAIN],
+                                   columns=dataset[DatasetConstants.NUMERIC] + dataset[DatasetConstants.CATEGORICAL])
+            X_test = pd.DataFrame(data=dataset[DatasetConstants.X_TEST],
+                                  columns=dataset[DatasetConstants.NUMERIC] + dataset[DatasetConstants.CATEGORICAL])
+
         y_train = dataset[DatasetConstants.Y_TRAIN]
-        model = create_lightgbm_classifier(X_train, y_train)
+        if dataset_name == 'iris':
+            model = create_lightgbm_classifier(X_train, y_train)
+        else:
+            model = create_titanic_pipeline(X_train, y_train)
 
         model_predict = model.predict(X_test)
         model_predict_proba = model.predict_proba(X_test)
@@ -51,24 +66,6 @@ class TestPredictionsWrapper:
 
         self.verify_predict_outputs(model, model_wrapper, X_test)
         self.verify_predict_proba_outputs(model, model_wrapper, X_test)
-        self.verify_pickle_serialization(model, model_wrapper, X_test)
-
-    def test_prediction_wrapper_regression(self, housing):
-        dataset = housing
-        X_train = pd.DataFrame(data=dataset[DatasetConstants.X_TRAIN],
-                               columns=dataset[DatasetConstants.FEATURES])
-        X_test = pd.DataFrame(data=dataset[DatasetConstants.X_TEST],
-                              columns=dataset[DatasetConstants.FEATURES])
-        y_train = dataset[DatasetConstants.Y_TRAIN]
-        model = create_lightgbm_regressor(X_train, y_train)
-
-        model_predict = model.predict(X_test)
-
-        model_wrapper = PredictionsModelWrapperRegression(
-            X_test, model_predict)
-
-        self.verify_predict_outputs(model, model_wrapper, X_test)
-        assert not hasattr(model_wrapper, "predict_proba")
         self.verify_pickle_serialization(model, model_wrapper, X_test)
 
     def test_prediction_wrapper_unsupported_scenarios(self, iris):
@@ -166,3 +163,23 @@ class TestPredictionsWrapper:
                 EmptyDataException,
                 match="The query data was not found in the combined dataset"):
             model_wrapper.predict_proba(X_test[len(X_test) - 1:len(X_test)])
+
+
+class TestPredictionsWrapperRegression(TestPredictionsWrapper):
+    def test_prediction_wrapper_regression(self, housing):
+        dataset = housing
+        X_train = pd.DataFrame(data=dataset[DatasetConstants.X_TRAIN],
+                               columns=dataset[DatasetConstants.FEATURES])
+        X_test = pd.DataFrame(data=dataset[DatasetConstants.X_TEST],
+                              columns=dataset[DatasetConstants.FEATURES])
+        y_train = dataset[DatasetConstants.Y_TRAIN]
+        model = create_lightgbm_regressor(X_train, y_train)
+
+        model_predict = model.predict(X_test)
+
+        model_wrapper = PredictionsModelWrapperRegression(
+            X_test, model_predict)
+
+        self.verify_predict_outputs(model, model_wrapper, X_test)
+        assert not hasattr(model_wrapper, "predict_proba")
+        self.verify_pickle_serialization(model, model_wrapper, X_test)


### PR DESCRIPTION
Adding a unit test to cover the scenario when there can be string features in the dataset.

Signed-off-by: Gaurav Gupta <gaugup@microsoft.com>