### PR TITLE
add multilabel text model wrapper

### DIFF
--- a/python/ml_wrappers/common/constants.py
+++ b/python/ml_wrappers/common/constants.py
@@ -180,6 +180,7 @@ class ModelTask(str, Enum):
     CLASSIFICATION = 'classification'
     REGRESSION = 'regression'
     TEXT_CLASSIFICATION = 'text_classification'
+    MULTILABEL_TEXT_CLASSIFICATION = 'multilabel_text_classification'
     SENTIMENT_ANALYSIS = 'sentiment_analysis'
     QUESTION_ANSWERING = 'question_answering'
     ENTAILMENT = 'entailment'
@@ -311,6 +312,7 @@ class ResetIndex(str, Enum):
 
 
 text_model_tasks = {ModelTask.TEXT_CLASSIFICATION,
+                    ModelTask.MULTILABEL_TEXT_CLASSIFICATION,
                     ModelTask.SENTIMENT_ANALYSIS,
                     ModelTask.QUESTION_ANSWERING,
                     ModelTask.ENTAILMENT,

--- a/python/ml_wrappers/model/model_utils.py
+++ b/python/ml_wrappers/model/model_utils.py
@@ -1,0 +1,22 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+"""Defines common model utilities."""
+
+from ml_wrappers.common.warnings_suppressor import shap_warnings_suppressor
+
+with shap_warnings_suppressor():
+    try:
+        from shap.utils import safe_isinstance
+        shap_installed = True
+    except BaseException:
+        shap_installed = False
+
+
+MULTILABEL_THRESHOLD = 0.5
+
+
+def _is_transformers_pipeline(model):
+    return shap_installed and safe_isinstance(
+        model, "transformers.pipelines.Pipeline")

--- a/tests/common_text_utils.py
+++ b/tests/common_text_utils.py
@@ -1,12 +1,22 @@
 # Copyright (c) Microsoft Corporation
 # Licensed under the MIT License.
 
+import zipfile
+
 import datasets
 import pandas as pd
+from raiutils.common.retries import retry_function
 from transformers import (AutoModelForSequenceClassification, AutoTokenizer,
                           pipeline)
 
+try:
+    from urllib import urlretrieve
+except ImportError:
+    from urllib.request import urlretrieve
+
+
 EMOTION = 'emotion'
+COVID19_EVENTS_MODEL_NAME = "covid19_events_model"
 
 
 def load_emotion_dataset():
@@ -30,6 +40,23 @@ def load_squad_dataset():
     return data
 
 
+def load_covid19_emergency_event_dataset():
+    dataset = datasets.load_dataset("joelito/covid19_emergency_event", split="train")
+    dataset = pd.DataFrame({"language": dataset["language"],
+                            "text": dataset["text"],
+                            "event1": dataset["event1"],
+                            "event2": dataset["event2"],
+                            "event3": dataset["event3"],
+                            "event4": dataset["event4"],
+                            "event5": dataset["event5"],
+                            "event6": dataset["event6"],
+                            "event7": dataset["event7"],
+                            "event8": dataset["event8"]})
+    dataset = dataset[dataset.language == "en"].reset_index(drop=True)
+    dataset = dataset.drop(columns="language")
+    return dataset
+
+
 def create_text_classification_pipeline():
     # load the model and tokenizer
     tokenizer = AutoTokenizer.from_pretrained(
@@ -46,3 +73,47 @@ def create_text_classification_pipeline():
 
 def create_question_answering_pipeline():
     return pipeline('question-answering')
+
+
+class FetchCovid19Model(object):
+    def __init__(self):
+        pass
+
+    def fetch(self):
+        zipfilename = COVID19_EVENTS_MODEL_NAME + '.zip'
+        url = ('https://publictestdatasets.blob.core.windows.net/models/' +
+               COVID19_EVENTS_MODEL_NAME + '.zip')
+        urlretrieve(url, zipfilename)
+        with zipfile.ZipFile(zipfilename, 'r') as unzip:
+            unzip.extractall(COVID19_EVENTS_MODEL_NAME)
+
+
+def create_multilabel_text_pipeline():
+    fetcher = FetchCovid19Model()
+    action_name = "Model download"
+    err_msg = "Failed to download model"
+    max_retries = 4
+    retry_delay = 60
+    retry_function(fetcher.fetch, action_name, err_msg,
+                   max_retries=max_retries,
+                   retry_delay=retry_delay)
+    labels = ["event1", "event2", "event3", "event4", "event5", "event6", "event7", "event8"]
+    num_labels = len(labels)
+    id2label = {idx: label for idx, label in enumerate(labels)}
+    label2id = {label: idx for idx, label in enumerate(labels)}
+    model = AutoModelForSequenceClassification.from_pretrained(
+        COVID19_EVENTS_MODEL_NAME, num_labels=num_labels,
+        problem_type="multi_label_classification",
+        id2label=id2label,
+        label2id=label2id)
+    tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
+    device = -1
+    # build a pipeline object to do predictions
+    pred = pipeline(
+        "text-classification",
+        model=model,
+        tokenizer=tokenizer,
+        device=device,
+        return_all_scores=True
+    )
+    return pred

--- a/tests/test_text_model_wrapper.py
+++ b/tests/test_text_model_wrapper.py
@@ -5,12 +5,15 @@
 """Tests for wrap_model function on text-based models"""
 
 import pytest
-from common_text_utils import (EMOTION, create_question_answering_pipeline,
+from common_text_utils import (EMOTION, create_multilabel_text_pipeline,
+                               create_question_answering_pipeline,
                                create_text_classification_pipeline,
+                               load_covid19_emergency_event_dataset,
                                load_emotion_dataset, load_squad_dataset)
 from ml_wrappers import wrap_model
 from ml_wrappers.common.constants import ModelTask
 from wrapper_validator import (validate_wrapped_classification_model,
+                               validate_wrapped_multilabel_model,
                                validate_wrapped_question_answering_model)
 
 
@@ -29,3 +32,12 @@ class TestTextModelWrapper(object):
         pred = create_question_answering_pipeline()
         wrapped_model = wrap_model(pred, docs, ModelTask.QUESTION_ANSWERING)
         validate_wrapped_question_answering_model(wrapped_model, docs)
+
+    def test_wrap_multilabel_model(self):
+        covid19_data = load_covid19_emergency_event_dataset()
+        docs = covid19_data[:10]['text'].values.tolist()
+        pred = create_multilabel_text_pipeline()
+        wrapped_model = wrap_model(
+            pred, docs, ModelTask.MULTILABEL_TEXT_CLASSIFICATION)
+        num_labels = pred.model.num_labels
+        validate_wrapped_multilabel_model(wrapped_model, docs, num_labels)

--- a/tests/wrapper_validator.py
+++ b/tests/wrapper_validator.py
@@ -12,14 +12,28 @@ PREDICT_CLASSES = 'predict_classes'
 
 def validate_wrapped_classification_model(wrapped_model, X_test):
     # validate wrapped model has predict and predict_proba functions
-    assert hasattr(wrapped_model, SKLearn.PREDICT)
-    assert hasattr(wrapped_model, SKLearn.PREDICT_PROBA)
+    function_names = [SKLearn.PREDICT, SKLearn.PREDICT_PROBA]
+    validate_functions(wrapped_model, function_names)
     # validate we can call the model on the dataset
     predictions = wrapped_model.predict(X_test)
     probabilities = wrapped_model.predict_proba(X_test)
     # validate predictions and probabilities have correct shape
     assert len(predictions.shape) == 1
     assert len(probabilities.shape) == 2
+
+
+def validate_wrapped_multilabel_model(wrapped_model, X_test, num_labels):
+    # validate wrapped model has predict and predict_proba functions
+    function_names = [SKLearn.PREDICT, SKLearn.PREDICT_PROBA]
+    validate_functions(wrapped_model, function_names)
+    # validate we can call the model on the dataset
+    predictions = wrapped_model.predict(X_test)
+    probabilities = wrapped_model.predict_proba(X_test)
+    # validate predictions and probabilities have correct shape
+    assert len(predictions.shape) == 2
+    assert len(probabilities.shape) == 2
+    assert predictions.shape[1] == num_labels
+    assert probabilities.shape[1] == num_labels
 
 
 def validate_wrapped_regression_model(wrapped_model, X_test):
@@ -54,9 +68,8 @@ def validate_wrapped_pytorch_model(wrapped_pytorch_model, X_test, model_task):
 
 
 def validate_wrapped_pred_classes_model(wrapped_model, X_test, model_task):
-    assert hasattr(wrapped_model, SKLearn.PREDICT)
-    assert hasattr(wrapped_model, SKLearn.PREDICT_PROBA)
-    assert hasattr(wrapped_model, PREDICT_CLASSES)
+    function_names = [SKLearn.PREDICT, SKLearn.PREDICT_PROBA, PREDICT_CLASSES]
+    validate_functions(wrapped_model, function_names)
     # validate we can call the model on the dataset
     if model_task == ModelTask.CLASSIFICATION:
         probabilities = wrapped_model.predict_proba(X_test)
@@ -69,3 +82,8 @@ def validate_wrapped_pred_classes_model(wrapped_model, X_test, model_task):
         # validate predictions have correct shape
         print(predictions.shape)
         assert len(predictions.shape) == 1 or predictions.shape[1] == 1
+
+
+def validate_functions(wrapped_model, function_names):
+    for function_name in function_names:
+        assert hasattr(wrapped_model, function_name)


### PR DESCRIPTION
Add wrapper for multilabel huggingface models in wrap_model method.

Given the scikit-learn docs here:

https://scikit-learn.org/stable/modules/multiclass.html?highlight=multilabel#multilabel-classification

The common wrapper will follow the format of the multioutput classifier:

https://scikit-learn.org/stable/modules/generated/sklearn.multioutput.MultiOutputClassifier.html#sklearn.multioutput.MultiOutputClassifier.predict

This format is a two-dimensional indicator array by num rows X num labels, where for index i = 1 if the corresponding label is output by the model:

https://scikit-learn.org/stable/modules/generated/sklearn.multioutput.MultiOutputClassifier.html#sklearn.multioutput.MultiOutputClassifier.predict