### PR TITLE
return scikit-image style by default if not matched to model specific type

### DIFF
--- a/python/ml_wrappers/model/image_model_wrapper.py
+++ b/python/ml_wrappers/model/image_model_wrapper.py
@@ -12,6 +12,8 @@ import pandas as pd
 from ml_wrappers.common.constants import ModelTask
 from ml_wrappers.dataset.dataset_wrapper import DatasetWrapper
 from ml_wrappers.model.evaluator import _eval_model
+from ml_wrappers.model.model_utils import (_is_callable_pipeline,
+                                           _is_transformers_pipeline)
 from ml_wrappers.model.pytorch_wrapper import WrappedPytorchModel
 from ml_wrappers.model.wrapped_classification_model import \
     WrappedClassificationModel
@@ -272,7 +274,7 @@ def _wrap_image_model(model, examples, model_task, is_function,
             ):
                 _wrapped_model = WrappedMlflowAutomlImagesClassificationModel(
                     model)
-        else:
+        elif _is_transformers_pipeline(model) or _is_callable_pipeline(model):
             _wrapped_model = WrappedTransformerImageClassificationModel(model)
     elif model_task == ModelTask.MULTILABEL_IMAGE_CLASSIFICATION:
         if _is_fastai_model(model):

--- a/python/ml_wrappers/model/model_utils.py
+++ b/python/ml_wrappers/model/model_utils.py
@@ -18,5 +18,27 @@ MULTILABEL_THRESHOLD = 0.5
 
 
 def _is_transformers_pipeline(model):
+    """Checks if the model is a transformers pipeline.
+
+    :param model: The model to check.
+    :type model: object
+    :return: True if the model is a transformers pipeline, False otherwise.
+    :rtype: bool
+    """
     return shap_installed and safe_isinstance(
         model, "transformers.pipelines.Pipeline")
+
+
+def _is_callable_pipeline(model):
+    """Checks if the model is a callable pipeline.
+
+    Returns false if the model has a predict and predict_proba method.
+
+    :param model: The model to check.
+    :type model: object
+    :return: True if the model is a callable pipeline, False otherwise.
+    :rtype: bool
+    """
+    has_predict = hasattr(model, 'predict')
+    has_predict_proba = hasattr(model, 'predict_proba')
+    return callable(model) and not has_predict and not has_predict_proba

--- a/tests/common_vision_utils.py
+++ b/tests/common_vision_utils.py
@@ -194,7 +194,50 @@ class ResNetPipeline(object):
 
 
 def create_image_classification_pipeline():
+    """Create a pipeline for image classification.
+
+    :return: pipeline
+    :rtype: ResNetPipeline
+    """
     return ResNetPipeline()
+
+
+class ScikitResNetPipeline(object):
+    def __init__(self):
+        """Creates a scikit-learn compatible pipeline for image classification.
+        """
+        self.model = ResNet50(weights='imagenet')
+
+    def predict(self, X):
+        """Predicts the class for each image in the dataset.
+
+        :param X: dataset
+        :type X: numpy.ndarray
+        :return: predicted classes
+        :rtype: numpy.ndarray
+        """
+        return np.argmax(self.predict_proba(X), axis=1)
+
+    def predict_proba(self, X):
+        """Predicts the probability of each class for each image in the dataset.
+
+        :param X: dataset
+        :type X: numpy.ndarray
+        :return: predicted probabilities
+        :rtype: numpy.ndarray
+        """
+        tmp = X.copy()
+        preprocess_input(tmp)
+        return self.model(tmp)
+
+
+def create_scikit_classification_pipeline():
+    """Create a scikit-learn compatible pipeline for image classification.
+
+    :return: scikit-learn compatible pipeline
+    :rtype: ScikitResNetPipeline
+    """
+    return ScikitResNetPipeline()
 
 
 class FetchModel(object):

--- a/tests/main/test_image_model_wrapper.py
+++ b/tests/main/test_image_model_wrapper.py
@@ -12,6 +12,7 @@ import pytest
 import torchvision
 from common_vision_utils import (IMAGE, create_image_classification_pipeline,
                                  create_pytorch_image_model,
+                                 create_scikit_classification_pipeline,
                                  load_fridge_dataset, load_imagenet_dataset,
                                  load_images, load_multilabel_fridge_dataset,
                                  load_object_fridge_dataset,
@@ -38,6 +39,12 @@ class TestImageModelWrapper(object):
     def test_wrap_resnet_classification_model(self):
         data = load_imagenet_dataset()
         pred = create_image_classification_pipeline()
+        wrapped_model = wrap_model(pred, data, ModelTask.IMAGE_CLASSIFICATION)
+        validate_wrapped_classification_model(wrapped_model, data)
+
+    def test_wrap_scikit_classification_model(self):
+        data = load_imagenet_dataset()
+        pred = create_scikit_classification_pipeline()
         wrapped_model = wrap_model(pred, data, ModelTask.IMAGE_CLASSIFICATION)
         validate_wrapped_classification_model(wrapped_model, data)
 


### PR DESCRIPTION
When given a scikit-learn style model with predict and predict_proba functions for the image classification task, we were previously wrapping it by default with the transformers wrapper.  This doesn't make sense, and causes issues for such types of models.  This PR updates the image classification wrapping logic to just return the scikit-learn style models by default for image classification case.