### PR TITLE
fix failing tests on emotion dataset

### DIFF
--- a/tests/common_text_utils.py
+++ b/tests/common_text_utils.py
@@ -15,12 +15,13 @@ except ImportError:
     from urllib.request import urlretrieve
 
 
+EMOTION_DATASET = 'SetFit/emotion'
 EMOTION = 'emotion'
 COVID19_EVENTS_MODEL_NAME = "covid19_events_model"
 
 
 def load_emotion_dataset():
-    dataset = datasets.load_dataset(EMOTION, split="train")
+    dataset = datasets.load_dataset(EMOTION_DATASET, split="train")
     data = pd.DataFrame({'text': dataset['text'],
                          EMOTION: dataset['label']})
     return data

--- a/tests/common_utils.py
+++ b/tests/common_utils.py
@@ -244,7 +244,7 @@ def wrap_classifier_without_proba(classifier):
 
 
 def create_sklearn_linear_regressor(X, y, pipeline=False):
-    lin = linear_model.LinearRegression(normalize=True)
+    lin = linear_model.LinearRegression()
     if pipeline:
         lin = Pipeline([('lin', lin)])
     model = lin.fit(X, y)


### PR DESCRIPTION
There seems to be a known issue with emotion dataset on huggingface failing to download, see:

https://github.com/dair-ai/emotion_dataset/issues/5

The dataset is hosted externally,
Using an alternative link to the dataset on huggingface which is hosted internally.

Update: Also remove normalize parameter as it has been removed on latest scikit-learn pypi package's LinearRegression class to unblock failing builds.