### PR TITLE
fix failing ml-wrappers release build due to automl tests being included without dependencies installed

### DIFF
--- a/.github/workflows/release-ml-wrappers.yml
+++ b/.github/workflows/release-ml-wrappers.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: run ml-wrappers tests
         shell: bash -l {0}
-        run: pytest ./tests/
+        run: pytest ./tests/main
 
       - name: Upload a ml-wrappers build result
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Hotfix for release build failing:

https://github.com/microsoft/ml-wrappers/actions/runs/3659856132

The release build includes the full tests folder which runs the AutoML tests.  However, the newly added AutoML tests don't have dependencies installed in the release build.  This PR changes the command to only run the main tests in the main folder and excludes the AutoML tests, which are run on gated builds anyway already.