### PR TITLE
hotfix to ml-wrappers to make mlflow PyFuncModel import optional (no hard dependency) which is causing upstream errors

### DIFF
--- a/python/ml_wrappers/model/image_model_wrapper.py
+++ b/python/ml_wrappers/model/image_model_wrapper.py
@@ -6,7 +6,6 @@
 
 import logging
 
-import mlflow
 import numpy as np
 import pandas as pd
 from ml_wrappers.common.constants import ModelTask
@@ -24,6 +23,13 @@ try:
     import torch.nn as nn
 except ImportError:
     module_logger.debug('Could not import torch, required if using a PyTorch model')
+
+try:
+    from mlflow.pyfunc import PyFuncModel
+except ImportError:
+    from typing import Any
+    PyFuncModel = Any
+    module_logger.debug('Could not import mlflow, required if using an mlflow model')
 
 
 FASTAI_MODEL_SUFFIX = "fastai.learner.Learner'>"
@@ -186,7 +192,7 @@ class WrappedFastAIImageClassificationModel(object):
 class WrappedMlflowAutomlImagesClassificationModel:
     """A class for wrapping an AutoML for images MLflow model in the scikit-learn style."""
 
-    def __init__(self, model: mlflow.pyfunc.PyFuncModel) -> None:
+    def __init__(self, model: PyFuncModel) -> None:
         """Initialize the WrappedMlflowAutomlImagesClassificationModel.
 
         :param model: mlflow model

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,3 @@ transformers<4.20.0
 datasets
 raiutils
 fastai
-mlflow


### PR DESCRIPTION
hotfix to ml-wrappers to make mlflow PyFuncModel import optional (no hard dependency) which is causing upstream errors

mlflow is getting automatically imported and failing in many environments where it is not needed and is not installed.
This is caused by the import added in the recent PR https://github.com/microsoft/ml-wrappers/pull/73 .
The fix here is to take a soft dependency on the import.
