### PR TITLE
release ml-wrappers 0.4.2

### DIFF
--- a/python/ml_wrappers/version.py
+++ b/python/ml_wrappers/version.py
@@ -1,5 +1,5 @@
 name = 'ml_wrappers'
 _major = '0'
 _minor = '4'
-_patch = '1'
+_patch = '2'
 version = '{}.{}.{}'.format(_major, _minor, _patch)


### PR DESCRIPTION
* hotfix to ml-wrappers to make mlflow PyFuncModel import optional (no hard dependency) which is causing upstream errors by @imatiach-msft in https://github.com/microsoft/ml-wrappers/pull/79


**Full Changelog**: https://github.com/microsoft/ml-wrappers/compare/v0.4.1...v0.4.2