### PR TITLE
Add python 3.10 to setup.py and docs

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,6 +1,6 @@
 # Machine Learning Wrappers SDK for Python
 
-### This package has been tested with Python 3.6, 3.7, 3.8 and 3.9
+### This package has been tested with Python 3.6, 3.7, 3.8, 3.9 and 3.10
 
 The Machine Learning Wrappers SDK provides a unified wrapper for various ML frameworks - to have one uniform scikit-learn format predict and predict_proba functions.
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -30,6 +30,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
     'Topic :: Scientific/Engineering :: Artificial Intelligence',
     'Operating System :: Microsoft :: Windows',
     'Operating System :: MacOS',


### PR DESCRIPTION
It looks like we have tests for python 3.10 but we don't show it in setup.py or the docs.

Signed-off-by: Gaurav Gupta <gaugup@microsoft.com>