### PR TITLE
fix fastai get_preds on inference when callbacks failing

### DIFF
--- a/python/ml_wrappers/model/fastai_wrapper.py
+++ b/python/ml_wrappers/model/fastai_wrapper.py
@@ -30,9 +30,42 @@ class WrappedFastAITabularModel(object):
         :type model: fastai.learner.Learner
         """
         self._model = model
+        dl = self._model.dls[0]
+        self.cat_cols = dl.dataset.cat_names
+        self.cont_cols = dl.dataset.cont_names
 
-    def _fastai_predict(self, dataset, index):
+    def _fastai_predict(self, dataset, index, model=None):
         """Predict the output using the wrapped FastAI model.
+
+        :param dataset: The dataset to predict on.
+        :type dataset: ml_wrappers.DatasetWrapper
+        :param index: The index into the predicted data.
+            Index 1 is for the predicted class and index
+            2 is for the predicted probability.
+        :type index: int
+        :param model: The model to use for prediction.
+            If None, the wrapped model is used.
+        :type model: fastai.learner.Learner
+        :return: The predicted data.
+        :rtype: numpy.ndarray
+        """
+        if model is None:
+            model = self._model
+        predictions = []
+        for i in range(len(dataset)):
+            row = dataset.iloc[i]
+            # get only feature columns for prediction
+            row = row[self.cat_cols + self.cont_cols]
+            predictions.append(np.array(model.predict(row)[index]))
+        predictions = np.array(predictions)
+        if index == 1:
+            is_boolean = predictions.dtype == bool
+            if is_boolean:
+                predictions = predictions.astype(int)
+        return predictions
+
+    def _fastai_predict_without_callbacks(self, dataset, index):
+        """Predict the output using the wrapped FastAI model without callbacks.
 
         :param dataset: The dataset to predict on.
         :type dataset: ml_wrappers.DatasetWrapper
@@ -43,16 +76,13 @@ class WrappedFastAITabularModel(object):
         :return: The predicted data.
         :rtype: numpy.ndarray
         """
-        predictions = []
-        for i in range(len(dataset)):
-            row = dataset.iloc[i]
-            predictions.append(np.array(self._model.predict(row)[index]))
-        predictions = np.array(predictions)
-        if index == 1:
-            is_boolean = predictions.dtype == bool
-            if is_boolean:
-                predictions = predictions.astype(int)
-        return predictions
+        removed_cbs = []
+        default_cbs = ['TrainEvalCallback', 'Recorder', 'CastToTensor']
+        for cb in self._model.cbs:
+            if cb.__class__.__name__ not in default_cbs:
+                removed_cbs.append(cb)
+        with self._model.removed_cbs(removed_cbs) as model:
+            return self._fastai_predict(dataset, index, model)
 
     def predict(self, dataset):
         """Predict the output value using the wrapped FastAI model.
@@ -62,7 +92,10 @@ class WrappedFastAITabularModel(object):
         :return: The predicted values.
         :rtype: numpy.ndarray
         """
-        return self._fastai_predict(dataset, 1)
+        try:
+            return self._fastai_predict(dataset, 1)
+        except Exception:
+            return self._fastai_predict_without_callbacks(dataset, 1)
 
     def predict_proba(self, dataset):
         """Predict the output probability using the FastAI model.
@@ -72,4 +105,7 @@ class WrappedFastAITabularModel(object):
         :return: The predicted probabilities.
         :rtype: numpy.ndarray
         """
-        return self._fastai_predict(dataset, 2)
+        try:
+            return self._fastai_predict(dataset, 2)
+        except Exception:
+            return self._fastai_predict_without_callbacks(dataset, 2)

--- a/tests/main/test_model_wrapper.py
+++ b/tests/main/test_model_wrapper.py
@@ -11,6 +11,7 @@ import pytest
 from common_utils import (create_catboost_classifier,
                           create_catboost_regressor,
                           create_fastai_tabular_classifier,
+                          create_fastai_tabular_classifier_multimetric,
                           create_fastai_tabular_regressor,
                           create_keras_classifier, create_keras_regressor,
                           create_lightgbm_classifier,
@@ -83,6 +84,18 @@ class TestModelWrapper(object):
                         reason='Fastai not supported for older versions')
     def test_wrap_fastai_classification_model(self, iris):
         train_classification_model_pandas(create_fastai_tabular_classifier, iris)
+
+    # Skip for older versions due to latest fastai not supporting 3.6
+    @pytest.mark.skipif(sys.version_info.minor <= 6,
+                        reason='Fastai not supported for older versions')
+    def test_wrap_fastai_classification_model_multimetric(self, iris):
+        iris = iris.copy()
+        data_to_transform = [DatasetConstants.Y_TRAIN, DatasetConstants.Y_TEST]
+        for data in data_to_transform:
+            iris[data][iris[data] == 2] = 1
+        train_classification_model_pandas(
+            create_fastai_tabular_classifier_multimetric, iris,
+            validate_single_row=True)
 
     def test_wrap_sklearn_linear_regression_model(self, housing):
         train_regression_model_numpy(

--- a/tests/train_wrapper_utils.py
+++ b/tests/train_wrapper_utils.py
@@ -29,7 +29,8 @@ def train_classification_model_numpy(model_initializer, dataset,
 
 
 def train_classification_model_pandas(model_initializer, dataset,
-                                      use_dataset_wrapper=True):
+                                      use_dataset_wrapper=True,
+                                      validate_single_row=False):
     X_train = pd.DataFrame(data=dataset[DatasetConstants.X_TRAIN],
                            columns=dataset[DatasetConstants.FEATURES])
     X_test = pd.DataFrame(data=dataset[DatasetConstants.X_TEST],
@@ -42,6 +43,8 @@ def train_classification_model_pandas(model_initializer, dataset,
         X_test_wrapped = X_test
     wrapped_model = wrap_model(model, X_test_wrapped,
                                model_task=ModelTask.CLASSIFICATION)
+    if validate_single_row:
+        validate_wrapped_classification_model(wrapped_model, X_test.iloc[0:1])
     validate_wrapped_classification_model(wrapped_model, X_test)
 
 


### PR DESCRIPTION
During customer debugging there were several issues discovered with the fastai model wrapper:
1.) Sometimes the predict call can evaluate some metrics if true label is included, and those metrics can fail when run on a single row.  The simple fix is to ensure that only the relevant feature columns are passed to the predict method call.
2.) Fastai has a complex system of callbacks and these can sometimes fail.  In case the predict call fails due to callbacks, this PR removes all but the most common system callbacks to ensure predict can still pass.