### PR TITLE
re-enable macos python tests in gated builds

### DIFF
--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         packageDirectory: ["ml_wrappers"]
-        operatingSystem: [ubuntu-latest, windows-latest]
+        operatingSystem: [ubuntu-latest, macos-latest, windows-latest]
         pythonVersion: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     runs-on: ${{ matrix.operatingSystem }}
@@ -29,21 +29,26 @@ jobs:
       shell: bash -l {0}
       run: |
         brew install libomp
-    - if: ${{ matrix.pythonVersion != '3.6' }}
-      name: Install numpy
+    - if: ${{ matrix.operatingSystem != 'macos-latest' && matrix.pythonVersion != '3.6' }}
+      name: Install pytorch on non-MacOS for python 3.7 to 3.10
       shell: bash -l {0}
       run: |
-        conda install --yes --quiet "numpy<=1.22.4" -c conda-forge
-    - if: ${{ matrix.operatingSystem != 'macos-latest' }}
-      name: Install pytorch on non-MacOS
+        conda install --yes --quiet pytorch torchvision captum cpuonly -c pytorch -c conda-forge
+    - if: ${{ matrix.operatingSystem != 'macos-latest' && matrix.pythonVersion == '3.6' }}
+      name: Install pytorch on non-MacOS for python 3.6
       shell: bash -l {0}
       run: |
-        conda install --yes --quiet pytorch torchvision captum cpuonly -c pytorch
-    - if: ${{ matrix.operatingSystem == 'macos-latest' }}
-      name: Install Anaconda packages on MacOS, which should not include cpuonly according to official docs
+        conda install --yes --quiet "pytorch<1.11.0" torchvision captum cpuonly -c pytorch
+    - if: ${{ matrix.operatingSystem == 'macos-latest' && matrix.pythonVersion != '3.6' }}
+      name: Install pytorch on MacOS for python 3.7 to 3.10
       shell: bash -l {0}
       run: |
-        conda install --yes --quiet pytorch torchvision captum -c pytorch
+        conda install --yes --quiet pytorch torchvision captum -c pytorch -c conda-forge
+    - if: ${{ matrix.operatingSystem == 'macos-latest' && matrix.pythonVersion == '3.6' }}
+      name: Install pytorch on MacOS for python 3.6
+      shell: bash -l {0}
+      run: |
+        conda install --yes --quiet "pytorch<1.11.0" torchvision captum -c pytorch
     - if: ${{ matrix.operatingSystem == 'macos-latest' }}
       name: Install lightgbm from conda on MacOS
       shell: bash -l {0}

--- a/tests/main/test_image_model_wrapper.py
+++ b/tests/main/test_image_model_wrapper.py
@@ -32,6 +32,9 @@ class TestImageModelWrapper(object):
     # Skip for older versions of python due to many breaking changes in fastai
     @pytest.mark.skipif(sys.version_info.minor <= 6,
                         reason='Fastai not supported for older versions')
+    # Skip is using macos due to fastai failing on latest macos
+    @pytest.mark.skipif(sys.platform == 'darwin',
+                        reason='Fastai not supported for latest macos')
     def test_wrap_fastai_image_classification_model(self):
         data = load_fridge_dataset()
         try:
@@ -77,6 +80,9 @@ class TestImageModelWrapper(object):
     # Skip for older versions of python due to many breaking changes in fastai
     @pytest.mark.skipif(sys.version_info.minor <= 6,
                         reason='Fastai not supported for older versions')
+    # Skip is using macos due to fastai failing on latest macos
+    @pytest.mark.skipif(sys.platform == 'darwin',
+                        reason='Fastai not supported for latest macos')
     def test_wrap_fastai_multilabel_image_classification_model(self):
         data = load_multilabel_fridge_dataset()
         try:

--- a/tests/main/test_model_wrapper.py
+++ b/tests/main/test_model_wrapper.py
@@ -82,12 +82,18 @@ class TestModelWrapper(object):
     # Skip for older versions due to latest fastai not supporting 3.6
     @pytest.mark.skipif(sys.version_info.minor <= 6,
                         reason='Fastai not supported for older versions')
+    # Skip is using macos due to fastai failing on latest macos
+    @pytest.mark.skipif(sys.platform == 'darwin',
+                        reason='Fastai not supported for latest macos')
     def test_wrap_fastai_classification_model(self, iris):
         train_classification_model_pandas(create_fastai_tabular_classifier, iris)
 
     # Skip for older versions due to latest fastai not supporting 3.6
     @pytest.mark.skipif(sys.version_info.minor <= 6,
                         reason='Fastai not supported for older versions')
+    # Skip is using macos due to fastai failing on latest macos
+    @pytest.mark.skipif(sys.platform == 'darwin',
+                        reason='Fastai not supported for latest macos')
     def test_wrap_fastai_classification_model_multimetric(self, iris):
         iris = iris.copy()
         data_to_transform = [DatasetConstants.Y_TRAIN, DatasetConstants.Y_TEST]
@@ -136,6 +142,9 @@ class TestModelWrapper(object):
     # Skip for older versions due to latest fastai not supporting 3.6
     @pytest.mark.skipif(sys.version_info.minor <= 6,
                         reason='Fastai not supported for older versions')
+    # Skip is using macos due to fastai failing on latest macos
+    @pytest.mark.skipif(sys.platform == 'darwin',
+                        reason='Fastai not supported for latest macos')
     def test_wrap_fastai_regression_model(self, iris):
         train_regression_model_pandas(create_fastai_tabular_regressor, iris)
 


### PR DESCRIPTION
The gated builds were failing with a segfault which was fixed when updating pytorch to use latest version by including conda-forge channel during conda install.  When not installing with conda-forge channel included we were actually installing an older version of pytorch.

However, some fastai tests then started to fail with the error:

```
>       return t.to(device, dtype if t.is_floating_point() or t.is_complex() else None, non_blocking)
E       RuntimeError: Exception occured in `TrainEvalCallback` when calling event `before_fit`:
E       	The MPS backend is supported on MacOS 12.3+.Current OS version can be queried using `sw_vers`
```

It seems that fastai support for macos is sparse based on their readme documentation and issues:
https://github.com/fastai/fastai/
For example, on their main README they write:

```
You can install fastai on your own machines with conda (highly recommended), as long as you’re running Linux or Windows (NB: Mac is not supported). For Windows, please see the “Running on Windows” for important notes.
```

Hence, just disabling the fastai tests to resolve this last issue after the pytorch updates.
