### PR TITLE
reduce codecov uploads and add retry logic to fix frequent random build failures

### DIFF
--- a/.github/workflows/CI-python-AutoML.yml
+++ b/.github/workflows/CI-python-AutoML.yml
@@ -76,14 +76,38 @@ jobs:
         path: htmlcov
       # Use always() to always run this step to publish test results when there are test failures
       if: ${{ always() }}
-    - name: Upload coverage to Codecov
+    - if: ${{ (matrix.operatingSystem == 'windows-latest') && (matrix.pythonVersion == '3.8') }}
+      name: Upload to codecov
+      id: codecovupload1
       uses: codecov/codecov-action@v2
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: ./coverage.xml
         directory: .
         env_vars: OS,PYTHON
-        fail_ci_if_error: true
+        fail_ci_if_error: false
+        files: ./coverage.xml
         flags: unittests
         name: codecov-umbrella
         verbose: true
+    - if: ${{ (steps.codecovupload1.outcome == 'failure') && (matrix.pythonVersion == '3.8') && (matrix.operatingSystem == 'windows-latest') }}
+      name: Retry upload to codecov
+      id: codecovupload2
+      uses: codecov/codecov-action@v2
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        directory: .
+        env_vars: OS,PYTHON
+        fail_ci_if_error: false
+        files: ./coverage.xml
+        flags: unittests
+        name: codecov-umbrella
+        verbose: true
+    - name: Set codecov status
+      if: ${{ (matrix.pythonVersion == '3.8') && (matrix.operatingSystem == 'windows-latest') }}
+      shell: bash
+      run: |
+        if ${{ (steps.codecovupload1.outcome == 'success') || (steps.codecovupload2.outcome == 'success') }} ; then
+          echo fine
+        else
+          exit 1
+        fi

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -77,14 +77,38 @@ jobs:
         path: htmlcov
       # Use always() to always run this step to publish test results when there are test failures
       if: ${{ always() }}
-    - name: Upload coverage to Codecov
+    - if: ${{ (matrix.operatingSystem == 'windows-latest') && (matrix.pythonVersion == '3.8') }}
+      name: Upload to codecov
+      id: codecovupload1
       uses: codecov/codecov-action@v2
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: ./coverage.xml
         directory: .
         env_vars: OS,PYTHON
-        fail_ci_if_error: true
+        fail_ci_if_error: false
+        files: ./coverage.xml
         flags: unittests
         name: codecov-umbrella
         verbose: true
+    - if: ${{ (steps.codecovupload1.outcome == 'failure') && (matrix.pythonVersion == '3.8') && (matrix.operatingSystem == 'windows-latest') }}
+      name: Retry upload to codecov
+      id: codecovupload2
+      uses: codecov/codecov-action@v2
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        directory: .
+        env_vars: OS,PYTHON
+        fail_ci_if_error: false
+        files: ./coverage.xml
+        flags: unittests
+        name: codecov-umbrella
+        verbose: true
+    - name: Set codecov status
+      if: ${{ (matrix.pythonVersion == '3.8') && (matrix.operatingSystem == 'windows-latest') }}
+      shell: bash
+      run: |
+        if ${{ (steps.codecovupload1.outcome == 'success') || (steps.codecovupload2.outcome == 'success') }} ; then
+          echo fine
+        else
+          exit 1
+        fi


### PR DESCRIPTION
Build failures seem to be happening frequently on codecov upload logic.  This PR attempts to fix these by making the logic more similar to https://github.com/microsoft/vision-explanation-methods/blob/main/.github/workflows/CI-python.yml and https://github.com/microsoft/responsible-ai-toolbox/blob/main/.github/workflows/CI-python.yml.  Specifically, we:
1.) only upload to codecov once, for a specific python environment + OS combination
2.) add retry logic, to retry codecov upload again if it failed
In the other repositories mentioned above this has resolved the codecov upload issue and hence it's expected to resolve the issue in the build + test script in this ml-wrappers repository too.