### PR TITLE
fix Pillow build error from libtiff 4.5.0

### DIFF
--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -29,8 +29,13 @@ jobs:
       shell: bash -l {0}
       run: |
         brew install libomp
-    - if: ${{ matrix.operatingSystem != 'macos-latest' && matrix.pythonVersion != '3.6' }}
-      name: Install pytorch on non-MacOS for python 3.7 to 3.10
+    - if: ${{ matrix.operatingSystem == 'windows-latest' && matrix.pythonVersion != '3.6' }}
+      name: Install pytorch on windows for python 3.7 to 3.10
+      shell: bash -l {0}
+      run: |
+        conda install --yes --quiet pytorch torchvision captum cpuonly "libtiff<4.5.0" -c pytorch -c conda-forge
+    - if: ${{ matrix.operatingSystem == 'ubuntu-latest' && matrix.pythonVersion != '3.6' }}
+      name: Install pytorch on ubuntu for python 3.7 to 3.10
       shell: bash -l {0}
       run: |
         conda install --yes --quiet pytorch torchvision captum cpuonly -c pytorch -c conda-forge


### PR DESCRIPTION
This PR fixes build errors that started occurring on the windows platform with libtiff 4.5.0 update.

The runtime test errors are:

```
C:\Miniconda\envs\test\lib\site-packages\transformers\utils\import_utils.py:874: in _get_module
    raise RuntimeError(
E   RuntimeError: Failed to import transformers.models.auto because of the following error (look up to see its traceback):
E   Failed to import transformers.onnx.config because of the following error (look up to see its traceback):
E   DLL load failed while importing _imaging: The specified module could not be found.
```