### PR TITLE
release ml-wrappers 0.4.5

### DIFF
--- a/python/ml_wrappers/version.py
+++ b/python/ml_wrappers/version.py
@@ -1,5 +1,5 @@
 name = 'ml_wrappers'
 _major = '0'
 _minor = '4'
-_patch = '4'
+_patch = '5'
 version = '{}.{}.{}'.format(_major, _minor, _patch)


### PR DESCRIPTION
* hotfix for ml-wrappers import for GeneralObjectDetectionModelWrapper when vision-explanation-methods package not installed by @imatiach-msft in https://github.com/microsoft/ml-wrappers/pull/95


**Full Changelog**: https://github.com/microsoft/ml-wrappers/compare/v0.4.4...v0.4.5