### PR TITLE
add test gate to validate ml-wrappers can be imported in an environment with minimal dependencies

### DIFF
--- a/.github/workflows/CI-python-minimal.yml
+++ b/.github/workflows/CI-python-minimal.yml
@@ -1,4 +1,4 @@
-name: CI Python AutoML
+name: CI Python minimal environment
 
 on:
   push:
@@ -9,12 +9,12 @@ on:
     - cron:  '30 5 * * *'
 
 jobs:
-  ci-python-automl:
+  ci-python-minimal:
     strategy:
       matrix:
         packageDirectory: ["ml_wrappers"]
         operatingSystem: [ubuntu-latest, macos-latest, windows-latest]
-        pythonVersion: ['3.7']
+        pythonVersion: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     runs-on: ${{ matrix.operatingSystem }}
 
@@ -24,39 +24,6 @@ jobs:
       with:
         auto-update-conda: true
         python-version: ${{ matrix.pythonVersion }}
-    - if: ${{ matrix.operatingSystem == 'macos-latest' }}
-      name: Use Homebrew to install libomp on MacOS
-      shell: bash -l {0}
-      run: |
-        brew install libomp
-    - if: ${{ matrix.pythonVersion != '3.6' }}
-      name: Install numpy
-      shell: bash -l {0}
-      run: |
-        conda install --yes --quiet "numpy<=1.22.4" -c conda-forge
-    - if: ${{ matrix.operatingSystem != 'macos-latest' }}
-      name: Install pytorch on non-MacOS
-      shell: bash -l {0}
-      run: |
-        conda install --yes --quiet pytorch torchvision captum cpuonly -c pytorch
-    - if: ${{ matrix.operatingSystem == 'macos-latest' }}
-      name: Install Anaconda packages on MacOS, which should not include cpuonly according to official docs
-      shell: bash -l {0}
-      run: |
-        conda install --yes --quiet pytorch torchvision captum -c pytorch
-    - if: ${{ matrix.operatingSystem == 'macos-latest' }}
-      name: Install lightgbm from conda on MacOS
-      shell: bash -l {0}
-      run: |
-        conda install --yes -c conda-forge lightgbm
-    - name: Install dev dependencies
-      shell: bash -l {0}
-      run: |
-        pip install -r requirements-dev.txt
-    - name: Install automl dependencies
-      shell: bash -l {0}
-      run: |
-        pip install -r requirements-automl.txt        
     - name: Install package
       shell: bash -l {0}
       run: |
@@ -68,7 +35,7 @@ jobs:
     - name: Test with pytest
       shell: bash -l {0}
       run: |
-        pytest ./tests/automl -s -v --durations=10 --cov='ml_wrappers' --cov-report=xml --cov-report=html
+        pytest ./tests/minimal -s -v --durations=10 --cov='ml_wrappers' --cov-report=xml --cov-report=html
     - name: Upload code coverage results
       uses: actions/upload-artifact@v3
       with:

--- a/python/ml_wrappers/model/image_model_wrapper.py
+++ b/python/ml_wrappers/model/image_model_wrapper.py
@@ -22,7 +22,9 @@ module_logger.setLevel(logging.INFO)
 try:
     import torch
     import torch.nn as nn
+    from torch import Tensor
 except ImportError:
+    Tensor = Any
     module_logger.debug('Could not import torch, required if using a' +
                         'PyTorch model')
 
@@ -345,7 +347,7 @@ class WrappedObjectDetectionModel:
         """
         detections = []
         for image in x:
-            if type(image) == torch.Tensor:
+            if type(image) == Tensor:
                 raw_detections = self._model(
                     image.to(self._device).unsqueeze(0))
             else:
@@ -401,7 +403,7 @@ class PytorchDRiseWrapper(GeneralObjectDetectionModelWrapper):
         self._model = model
         self._number_of_classes = number_of_classes
 
-    def predict(self, x: torch.Tensor):
+    def predict(self, x: Tensor):
         """Create a list of detection records from the image predictions.
 
         :param x: Tensor of the image

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,12 +7,18 @@ import os
 import tempfile
 
 import pytest
-from common_utils import (create_cancer_data, create_cancer_data_booleans,
-                          create_complex_titanic_data, create_diabetes_data,
-                          create_energy_data, create_housing_data,
-                          create_iris_data,
-                          create_multiclass_classification_dataset,
-                          create_simple_titanic_data, create_wine_data)
+
+try:
+    from common_utils import (create_cancer_data, create_cancer_data_booleans,
+                              create_complex_titanic_data,
+                              create_diabetes_data, create_energy_data,
+                              create_housing_data, create_iris_data,
+                              create_multiclass_classification_dataset,
+                              create_simple_titanic_data, create_wine_data)
+except ModuleNotFoundError:
+    print("Could not import common_utils, may be running minimal tests")
+    pass
+
 from constants import DatasetConstants
 
 test_logger = logging.getLogger(__name__)

--- a/tests/minimal/test_minimal.py
+++ b/tests/minimal/test_minimal.py
@@ -1,0 +1,19 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+"""Tests minimal imports and functions from ml-wrappers"""
+
+import pytest
+
+
+@pytest.mark.usefixtures('_clean_dir')
+class TestMinialImports(object):
+    def test_main_import(self):
+        import ml_wrappers  # noqa
+
+    def test_import_wrap_model(self):
+        from ml_wrappers import wrap_model  # noqa
+
+    def test_import_constants(self):
+        from ml_wrappers.common.constants import ModelTask  # noqa


### PR DESCRIPTION
After the release which broke downstream applications which led to the hotfix:
https://github.com/microsoft/ml-wrappers/pull/95

We realized we should add some additional test coverage to validate ml-wrappers can be imported in a "minimal" environment where only the most basic dependencies in the setup.py file are specified.  This PR adds this gate and some basic import tests.  We could add more validation logic as well in the future (eg calling wrap_model on a simple scikit-learn model in this minimal environment).

This PR also fixes another issue where Torch is imported and used in the code which will also fail if pytorch is not installed.  The new build/test gate actually caught this issue.