### PR TITLE
Update predictions_wrapper.py to change from iteritems() to items()

### DIFF
--- a/python/ml_wrappers/model/predictions_wrapper.py
+++ b/python/ml_wrappers/model/predictions_wrapper.py
@@ -48,7 +48,7 @@ class PredictionsModelWrapper:
         :rtype: pd.DataFrame
         """
         queries = []
-        for column_name, column_data in query_test_data_row.squeeze().iteritems():
+        for column_name, column_data in query_test_data_row.squeeze().items():
             if isinstance(column_data, str):
                 queries.append("`{}` == '{}'".format(
                     column_name, column_data))


### PR DESCRIPTION
Looks like using `iteritems()` will be deprecated in pandas 2.0.0. So using `items()` instead.