### PR TITLE
Adding support for Azure AutoML Mlflow Object Detection Models

### DIFF
--- a/python/ml_wrappers/model/image_model_wrapper.py
+++ b/python/ml_wrappers/model/image_model_wrapper.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Tuple, Union
 
 import numpy as np
 import pandas as pd
+
 from ml_wrappers.common.constants import ModelTask
 from ml_wrappers.dataset.dataset_wrapper import DatasetWrapper
 from ml_wrappers.model.evaluator import _eval_model
@@ -111,7 +112,7 @@ def _apply_nms(orig_prediction: dict, iou_thresh: float = 0.5):
 def _process_automl_detections_to_raw_detections(
         image_detections,
         label_dict: Dict[str, int],
-        image_size: Tuple[int, int]) -> Dict[str, torch.Tensor]:
+        image_size: Tuple[int, int]) -> Dict[str, Tensor]:
     """Process AutoML mlflow object detections from a single image.
 
     :param image_detections: AutoML mlflow detections
@@ -176,9 +177,9 @@ def _process_automl_detections_to_raw_detections(
         labels = [label_dict[x] for x in labels]
 
     return {
-        "boxes": torch.Tensor(boxes),
-        "labels": torch.Tensor(labels),
-        "scores": torch.Tensor(scores)}
+        "boxes": Tensor(boxes),
+        "labels": Tensor(labels),
+        "scores": Tensor(scores)}
 
 
 def _wrap_image_model(model, examples, model_task, is_function,
@@ -494,8 +495,6 @@ class WrappedMlflowAutomlObjectDetectionModel:
 
         self._model = model
         self._classes = classes
-        print("PRINTING")
-        print(classes)
         self._label_dict = {label: (i+1) for i, label in enumerate(classes)}
 
     def _mlflow_predict(self, dataset: pd.DataFrame) -> pd.DataFrame:

--- a/python/ml_wrappers/model/image_model_wrapper.py
+++ b/python/ml_wrappers/model/image_model_wrapper.py
@@ -483,18 +483,20 @@ class WrappedMlflowAutomlObjectDetectionModel:
         in the scikit-learn style."""
 
     def __init__(self, model: PyFuncModel,
-                 classes: Union[list, np.ndarray]) -> None:
+                 classes: Union[list, np.array]) -> None:
         """Initialize the WrappedMlflowAutomlObjectDetectionModel.
 
         :param model: mlflow model
         :type model: mlflow.pyfunc.PyFuncModel
         :param classes: list of class names
-        :type classes: list or np.ndarray
+        :type classes: list or np.array
         """
 
         self._model = model
         self._classes = classes
-        self._label_dict = {label: i for i, label in enumerate(classes, 1)}
+        print("PRINTING")
+        print(classes)
+        self._label_dict = {label: (i+1) for i, label in enumerate(classes)}
 
     def _mlflow_predict(self, dataset: pd.DataFrame) -> pd.DataFrame:
         """Perform the inference using the wrapped MLflow model.

--- a/python/ml_wrappers/model/image_model_wrapper.py
+++ b/python/ml_wrappers/model/image_model_wrapper.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, Tuple, Union
 
 import numpy as np
 import pandas as pd
-
 from ml_wrappers.common.constants import ModelTask
 from ml_wrappers.dataset.dataset_wrapper import DatasetWrapper
 from ml_wrappers.model.evaluator import _eval_model

--- a/python/ml_wrappers/model/image_model_wrapper.py
+++ b/python/ml_wrappers/model/image_model_wrapper.py
@@ -29,9 +29,11 @@ except ImportError:
                         'PyTorch model')
 
 try:
-    from vision_explanation_methods.explanations import common as od_common
-    from vision_explanation_methods.explanations.common import \
-        GeneralObjectDetectionModelWrapper
+    # from vision_explanation_methods.explanations import common as od_common
+    # from vision_explanation_methods.explanations.common import \
+    #     GeneralObjectDetectionModelWrapper
+    from responsibleai_vision.vision_explanation_methods_new.python.vision_explanation_methods.explanations import common as od_common
+    from responsibleai_vision.vision_explanation_methods_new.python.vision_explanation_methods.explanations.common import GeneralObjectDetectionModelWrapper
 except ImportError:
     GeneralObjectDetectionModelWrapper = object
     module_logger.debug('Could not import vision_explanation_methods,' +
@@ -605,6 +607,7 @@ class MLflowDRiseWrapper():
             # the predicted class. DRISE requires a score for each class.
             # We approximate the score for each class
             # by dividing (class score) evenly among the other classes.
+
             expanded_class_scores = od_common.expand_class_scores(
                 raw_detections[SCORES],
                 raw_detections[LABELS],

--- a/python/ml_wrappers/model/image_model_wrapper.py
+++ b/python/ml_wrappers/model/image_model_wrapper.py
@@ -29,11 +29,9 @@ except ImportError:
                         'PyTorch model')
 
 try:
-    # from vision_explanation_methods.explanations import common as od_common
-    # from vision_explanation_methods.explanations.common import \
-    #     GeneralObjectDetectionModelWrapper
-    from responsibleai_vision.vision_explanation_methods_new.python.vision_explanation_methods.explanations import common as od_common
-    from responsibleai_vision.vision_explanation_methods_new.python.vision_explanation_methods.explanations.common import GeneralObjectDetectionModelWrapper
+    from vision_explanation_methods.explanations import common as od_common
+    from vision_explanation_methods.explanations.common import \
+        GeneralObjectDetectionModelWrapper
 except ImportError:
     GeneralObjectDetectionModelWrapper = object
     module_logger.debug('Could not import vision_explanation_methods,' +
@@ -476,7 +474,7 @@ class WrappedMlflowAutomlObjectDetectionModel:
         dataset = dataset.drop(['image_size'], axis = 1)
 
         predictions = self._mlflow_predict(dataset)
-        assert len(predictions['boxes']) == len(image_sizes)
+        assert len(predictions['boxes']) == len(image_sizes), "Number of predictions does not match number of images"
 
         detections = []
         for image_detections, img_size in zip(predictions['boxes'], image_sizes):
@@ -567,82 +565,4 @@ class PytorchDRiseWrapper(GeneralObjectDetectionModelWrapper):
                         [1.0]*raw_detection[BOXES].shape[0]),
                 )
             )
-        return detections
-
-
-class MLflowDRiseWrapper():
-    """Wraps a Mlflow model with a predict API function.
-
-    To be compatible with the D-RISE explainability method,
-    all models must be wrapped to have the same output and input class and a
-    predict function for object detection. This wrapper is customized for the
-    FasterRCNN model from Pytorch, and can also be used with the RetinaNet or
-    any other models with the same output class.
-    """
-
-    def __init__(self, model: PyFuncModel, classes: Union[list, np.ndarray]) -> None:
-        """Initialize the MLflowDRiseWrapper.
-
-        :param model: mlflow model
-        :type model: mlflow.pyfunc.PyFuncModel
-        :param number_of_classes: Number of classes the model is predicting
-        :type number_of_classes: int
-        """
-        
-        self._model = model
-        self._classes = classes
-        self._number_of_classes = len(classes)
-        self._label_dict = {label: (i+1) for i, label in enumerate(classes)}
-        
-    def _mlflow_predict(self, dataset: pd.DataFrame) -> pd.DataFrame:
-        """Perform the inference using the wrapped MLflow model.
-
-        :param dataset: The dataset to predict on.
-        :type dataset: pandas.DataFrame
-        :return: The predicted data.
-        :rtype: pandas.DataFrame
-        """
-        predictions = self._model.predict(dataset)
-        return predictions
-
-    def predict(self, dataset: pd.DataFrame, iou_thresh: float = 0.005, score_thresh: float = 0.5):
-        """Predict the output value using the wrapped MLflow model.
-
-        :param dataset: The dataset to predict on.
-        :type dataset: pandas.DataFrame
-        :return: The predicted values.
-        :rtype: numpy.ndarray
-        """
-        image_sizes = dataset['image_size']
-
-        dataset = dataset.drop(['image_size'], axis=1)
-
-        predictions = self._mlflow_predict(dataset)
-        assert len(predictions['boxes']) == len(image_sizes)
-
-        detections = []
-        for image_detections, img_size in zip(predictions['boxes'], image_sizes):
-            raw_detections = _process_mlflow_detections_to_raw_detections(
-                image_detections, self._label_dict, img_size)
-            raw_detections = _apply_nms(raw_detections, iou_thresh)
-            raw_detections = _filter_score(raw_detections, score_thresh)
-
-            # Note that FasterRCNN doesn't return a score for each class, only
-            # the predicted class. DRISE requires a score for each class.
-            # We approximate the score for each class
-            # by dividing (class score) evenly among the other classes.
-
-            expanded_class_scores = od_common.expand_class_scores(
-                raw_detections[SCORES],
-                raw_detections[LABELS],
-                self._number_of_classes)
-
-            detections.append(
-                od_common.DetectionRecord(
-                    bounding_boxes=raw_detections[BOXES],
-                    class_scores=expanded_class_scores,
-                    objectness_scores=torch.tensor(
-                        [1.0]*raw_detections[BOXES].shape[0]),
-                ))
-
         return detections

--- a/python/ml_wrappers/model/image_model_wrapper.py
+++ b/python/ml_wrappers/model/image_model_wrapper.py
@@ -5,7 +5,7 @@
 """Defines wrappers for vision-based models."""
 
 import logging
-from typing import Any, Union, Dict, Tuple
+from typing import Any, Dict, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -182,7 +182,8 @@ def _process_automl_detections_to_raw_detections(
 
 
 def _wrap_image_model(model, examples, model_task, is_function,
-                      classes=None, number_of_classes=None):
+                      number_of_classes: int = None,
+                      classes: Union[list, np.array] = None):
     """If needed, wraps the model or function in a common API.
 
     Wraps the model based on model task and prediction function contract.

--- a/python/ml_wrappers/model/model_wrapper.py
+++ b/python/ml_wrappers/model/model_wrapper.py
@@ -54,6 +54,9 @@ def wrap_model(model, examples, model_task=ModelTask.UNKNOWN, classes=None, num_
         In most cases, the type of the model can be inferred based on the shape of the output, where a classifier
         has a predict_proba method and outputs a 2 dimensional array, while a regressor has a predict method and
         outputs a 1 dimensional array.
+    :param classes: optional parameter specifying a list of class names
+        the dataset
+    :type classes: list or np.ndarray
     :param num_classes: optional parameter specifying the number of classes in
         the dataset
     :type num_classes: int

--- a/python/ml_wrappers/model/model_wrapper.py
+++ b/python/ml_wrappers/model/model_wrapper.py
@@ -2,7 +2,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-"""Defines helpful model wrapper and utils for implicitly rewrapping the model to conform to explainer contracts."""
+"""Defines helpful model wrapper and utils for implicitly rewrapping the model
+    to conform to explainer contracts."""
 
 import logging
 import warnings
@@ -55,10 +56,13 @@ def wrap_model(model, examples, model_task: str = ModelTask.UNKNOWN,
     :type examples: ml_wrappers.DatasetWrapper or numpy.ndarray
         or pandas.DataFrame or panads.Series or scipy.sparse.csr_matrix
         or shap.DenseData or torch.Tensor
-    :param model_task: Optional parameter to specify whether the model is a classification or regression model.
-        In most cases, the type of the model can be inferred based on the shape of the output, where a classifier
-        has a predict_proba method and outputs a 2 dimensional array, while a regressor has a predict method and
-        outputs a 1 dimensional array.
+    :param model_task: Optional parameter to specify whether the model
+                       is a classification or regression model.
+                       In most cases, the type of the model can be inferred
+                       based on the shape of the output, where a classifier
+                       has a predict_proba method and outputs a 2 dimensional
+                       array, while a regressor has a predict method and
+                       outputs a 1 dimensional array.
     :param classes: optional parameter specifying a list of class names
         the dataset
     :type classes: list or np.ndarray
@@ -77,12 +81,13 @@ def wrap_model(model, examples, model_task: str = ModelTask.UNKNOWN,
         return _wrap_text_model(model, examples, model_task, False)[0]
     if model_task in image_model_tasks:
         return _wrap_image_model(model, examples, model_task,
-                                 False, classes, num_classes)[0]
+                                 False,  num_classes, classes)[0]
     return _wrap_model(model, examples, model_task, False)[0]
 
 
 def _wrap_model(model, examples, model_task, is_function):
-    """If needed, wraps the model or function in a common API based on model task and prediction function contract.
+    """If needed, wraps the model or function in a common API based on model
+        task and prediction function contract.
 
     :param model: The model or function to evaluate on the examples.
     :type model: function or model with a predict or predict_proba function
@@ -92,12 +97,16 @@ def _wrap_model(model, examples, model_task, is_function):
     :type examples: ml_wrappers.DatasetWrapper or numpy.ndarray
         or pandas.DataFrame or panads.Series or scipy.sparse.csr_matrix
         or shap.DenseData or torch.Tensor
-    :param model_task: Optional parameter to specify whether the model is a classification or regression model.
-        In most cases, the type of the model can be inferred based on the shape of the output, where a classifier
-        has a predict_proba method and outputs a 2 dimensional array, while a regressor has a predict method and
-        outputs a 1 dimensional array.
+    :param model_task: Optional parameter to specify whether the model
+                       is a classification or regression model.
+                       In most cases, the type of the model can be inferred
+                       based on the shape of the output, where a classifier
+                       has a predict_proba method and outputs a 2 dimensional
+                       array, while a regressor has a predict method and
+                       outputs a 1 dimensional array.
     :type model_task: str
-    :return: The function chosen from given model and chosen domain, or model wrapping the function and chosen domain.
+    :return: The function chosen from given model and chosen domain, or
+             model wrapping the function and chosen domain.
     :rtype: (function, str) or (model, str)
     """
     if not isinstance(examples, DatasetWrapper):
@@ -107,8 +116,11 @@ def _wrap_model(model, examples, model_task, is_function):
     else:
         try:
             if isinstance(model, nn.Module):
-                # Wrap the model in an extra layer that converts the numpy array
-                # to pytorch Variable and adds predict and predict_proba functions
+                # Wrap the model in an extra layer that
+                # converts the numpy array
+
+                # to pytorch Variable and adds predict and
+                # predict_proba functions
                 model = WrappedPytorchModel(model)
         except (NameError, AttributeError):
             module_logger.debug(
@@ -122,17 +134,21 @@ def _wrap_model(model, examples, model_task, is_function):
         eval_function, eval_ml_domain = _eval_model(
             model, examples, model_task)
         if eval_ml_domain == ModelTask.CLASSIFICATION:
-            return WrappedClassificationModel(model, eval_function, examples), eval_ml_domain
+            return WrappedClassificationModel(model, eval_function, examples),\
+                eval_ml_domain
         else:
-            return WrappedRegressionModel(model, eval_function, examples), eval_ml_domain
+            return WrappedRegressionModel(model, eval_function, examples), \
+                eval_ml_domain
 
 
 def _classifier_without_proba(model):
-    """Returns True if the given model is a classifier without predict_proba, eg SGDClassifier.
+    """Returns True if the given model is a classifier without predict_proba,
+        eg SGDClassifier.
 
     :param model: The model to evaluate on the examples.
     :type model: model with a predict or predict_proba function
     :return: True if the given model is a classifier without predict_proba.
     :rtype: bool
     """
-    return isinstance(model, SGDClassifier) and not hasattr(model, SKLearn.PREDICT_PROBA)
+    return isinstance(model, SGDClassifier) and not \
+        hasattr(model, SKLearn.PREDICT_PROBA)

--- a/python/ml_wrappers/model/model_wrapper.py
+++ b/python/ml_wrappers/model/model_wrapper.py
@@ -7,8 +7,8 @@
 import logging
 import warnings
 from typing import Union
-import numpy as np
 
+import numpy as np
 from ml_wrappers.model.wrapped_classification_model import \
     WrappedClassificationModel
 from ml_wrappers.model.wrapped_classification_without_proba_model import \
@@ -43,7 +43,7 @@ except ImportError:
 
 
 def wrap_model(model, examples, model_task: str = ModelTask.UNKNOWN,
-               classes: Union[list, np.array] = None, num_classes: int = None):
+               num_classes: int = None, classes: Union[list, np.array] = None):
     """If needed, wraps the model in a common API based on model task and
         prediction function contract.
 

--- a/python/ml_wrappers/model/model_wrapper.py
+++ b/python/ml_wrappers/model/model_wrapper.py
@@ -6,6 +6,7 @@
 
 import logging
 import warnings
+from typing import Union
 
 from ml_wrappers.model.wrapped_classification_model import \
     WrappedClassificationModel
@@ -38,7 +39,7 @@ except ImportError:
     module_logger.debug('Could not import torch, required if using a PyTorch model')
 
 
-def wrap_model(model, examples, model_task=ModelTask.UNKNOWN, num_classes=None):
+def wrap_model(model, examples, model_task=ModelTask.UNKNOWN, classes=None, num_classes=None):
     """If needed, wraps the model in a common API based on model task and prediction function contract.
 
     :param model: The model to evaluate on the examples.
@@ -67,7 +68,7 @@ def wrap_model(model, examples, model_task=ModelTask.UNKNOWN, num_classes=None):
     if model_task in text_model_tasks:
         return _wrap_text_model(model, examples, model_task, False)[0]
     if model_task in image_model_tasks:
-        return _wrap_image_model(model, examples, model_task, False, num_classes)[0]
+        return _wrap_image_model(model, examples, model_task, False, classes, num_classes)[0]
     return _wrap_model(model, examples, model_task, False)[0]
 
 

--- a/python/ml_wrappers/model/model_wrapper.py
+++ b/python/ml_wrappers/model/model_wrapper.py
@@ -10,13 +10,12 @@ import warnings
 from typing import Union
 
 import numpy as np
-from sklearn.linear_model import SGDClassifier
-
 from ml_wrappers.model.wrapped_classification_model import \
     WrappedClassificationModel
 from ml_wrappers.model.wrapped_classification_without_proba_model import \
     WrappedClassificationWithoutProbaModel
 from ml_wrappers.model.wrapped_regression_model import WrappedRegressionModel
+from sklearn.linear_model import SGDClassifier
 
 from ..common.constants import (ModelTask, SKLearn, image_model_tasks,
                                 text_model_tasks)

--- a/python/ml_wrappers/model/model_wrapper.py
+++ b/python/ml_wrappers/model/model_wrapper.py
@@ -10,12 +10,13 @@ import warnings
 from typing import Union
 
 import numpy as np
+from sklearn.linear_model import SGDClassifier
+
 from ml_wrappers.model.wrapped_classification_model import \
     WrappedClassificationModel
 from ml_wrappers.model.wrapped_classification_without_proba_model import \
     WrappedClassificationWithoutProbaModel
 from ml_wrappers.model.wrapped_regression_model import WrappedRegressionModel
-from sklearn.linear_model import SGDClassifier
 
 from ..common.constants import (ModelTask, SKLearn, image_model_tasks,
                                 text_model_tasks)

--- a/tests/automl/test_automl_image_model_wrapper.py
+++ b/tests/automl/test_automl_image_model_wrapper.py
@@ -21,11 +21,11 @@ from azureml.automl.dnn.vision.common.mlflow.mlflow_model_wrapper import \
     MLFlowImagesModelWrapper
 from azureml.automl.dnn.vision.common.model_export_utils import (
     _get_mlflow_signature, _get_scoring_method)
-from ml_wrappers import wrap_model
-from ml_wrappers.common.constants import ModelTask
-
 from common_vision_utils import load_base64_images, load_fridge_dataset
 from wrapper_validator import validate_wrapped_classification_model
+
+from ml_wrappers import wrap_model
+from ml_wrappers.common.constants import ModelTask
 
 
 @pytest.mark.usefixtures('_clean_dir')

--- a/tests/automl/test_automl_image_model_wrapper.py
+++ b/tests/automl/test_automl_image_model_wrapper.py
@@ -22,10 +22,10 @@ from azureml.automl.dnn.vision.common.mlflow.mlflow_model_wrapper import \
 from azureml.automl.dnn.vision.common.model_export_utils import (
     _get_mlflow_signature, _get_scoring_method)
 from common_vision_utils import load_base64_images, load_fridge_dataset
+from ml_wrappers.common.constants import ModelTask
 from wrapper_validator import validate_wrapped_classification_model
 
 from ml_wrappers import wrap_model
-from ml_wrappers.common.constants import ModelTask
 
 
 @pytest.mark.usefixtures('_clean_dir')

--- a/tests/automl/test_automl_image_model_wrapper.py
+++ b/tests/automl/test_automl_image_model_wrapper.py
@@ -29,10 +29,10 @@ from wrapper_validator import validate_wrapped_classification_model
 
 @pytest.mark.usefixtures('_clean_dir')
 class TestImageModelWrapper(object):
-    # Skip for older versions of python as azureml-automl-dnn-vision works with ">=3.7,<3.8"
+    # Skip for older versions of python as azureml-automl-dnn-vision works with ">=3.7,<3.9"
     @pytest.mark.skipif(sys.version_info < (3, 7),
                         reason='azureml-automl-dnn-vision not supported for older versions')
-    @pytest.mark.skipif(sys.version_info >= (3, 8),
+    @pytest.mark.skipif(sys.version_info >= (3, 9),
                         reason='azureml-automl-dnn-vision not supported for newer versions')
     def test_wrap_automl_image_classification_model(self):
         data = load_fridge_dataset()

--- a/tests/automl/test_automl_image_model_wrapper.py
+++ b/tests/automl/test_automl_image_model_wrapper.py
@@ -21,19 +21,23 @@ from azureml.automl.dnn.vision.common.mlflow.mlflow_model_wrapper import \
     MLFlowImagesModelWrapper
 from azureml.automl.dnn.vision.common.model_export_utils import (
     _get_mlflow_signature, _get_scoring_method)
-from common_vision_utils import load_base64_images, load_fridge_dataset
 from ml_wrappers import wrap_model
 from ml_wrappers.common.constants import ModelTask
+
+from common_vision_utils import load_base64_images, load_fridge_dataset
 from wrapper_validator import validate_wrapped_classification_model
 
 
 @pytest.mark.usefixtures('_clean_dir')
 class TestImageModelWrapper(object):
-    # Skip for older versions of python as azureml-automl-dnn-vision works with ">=3.7,<3.9"
-    @pytest.mark.skipif(sys.version_info < (3, 7),
-                        reason='azureml-automl-dnn-vision not supported for older versions')
-    @pytest.mark.skipif(sys.version_info >= (3, 9),
-                        reason='azureml-automl-dnn-vision not supported for newer versions')
+    # Skip for older versions of python as azureml-automl-dnn-vision
+    # works with ">=3.7,<3.9"
+    @pytest.mark.skipif(
+        sys.version_info < (3, 7),
+        reason='azureml-automl-dnn-vision not supported for older versions')
+    @pytest.mark.skipif(
+        sys.version_info >= (3, 9),
+        reason='azureml-automl-dnn-vision not supported for newer versions')
     def test_wrap_automl_image_classification_model(self):
         data = load_fridge_dataset()
         model_name = ModelNames.SERESNEXT
@@ -42,12 +46,13 @@ class TestImageModelWrapper(object):
 
             task_type = shared_constants.Tasks.IMAGE_CLASSIFICATION
             number_of_classes = 10
-            model_wrapper = ModelFactory().get_model_wrapper(model_name,
-                                                             number_of_classes,
-                                                             multilabel=multilabel,
-                                                             device="cpu",
-                                                             distributed=False,
-                                                             local_rank=0)
+            model_wrapper = ModelFactory().get_model_wrapper(
+                model_name,
+                number_of_classes,
+                multilabel=multilabel,
+                device="cpu",
+                distributed=False,
+                local_rank=0)
 
             # mock for Mlflow model generation
             model_file = os.path.join(tmp_output_dir, "model.pt")
@@ -63,7 +68,8 @@ class TestImageModelWrapper(object):
 
             }, model_file)
             settings_file = os.path.join(
-                tmp_output_dir, shared_constants.MLFlowLiterals.MODEL_SETTINGS_FILENAME)
+                tmp_output_dir,
+                shared_constants.MLFlowLiterals.MODEL_SETTINGS_FILENAME)
             remote_path = os.path.join(tmp_output_dir, "outputs")
 
             with open(settings_file, 'w') as f:
@@ -87,12 +93,13 @@ class TestImageModelWrapper(object):
                 scoring_method=_get_scoring_method(task_type)
             )
             print("Saving mlflow model at {}".format(remote_path))
-            mlflow.pyfunc.save_model(path=remote_path,
-                                     python_model=mlflow_model_wrapper,
-                                     artifacts={"model": model_file,
-                                                "settings": settings_file},
-                                     conda_env=conda_env,
-                                     signature=_get_mlflow_signature(task_type))
+            mlflow.pyfunc.save_model(
+                path=remote_path,
+                python_model=mlflow_model_wrapper,
+                artifacts={"model": model_file,
+                           "settings": settings_file},
+                conda_env=conda_env,
+                signature=_get_mlflow_signature(task_type))
             mlflow_model = mlflow.pyfunc.load_model(remote_path)
 
             # load the paths as base64 images

--- a/tests/automl/test_automl_image_model_wrapper.py
+++ b/tests/automl/test_automl_image_model_wrapper.py
@@ -22,10 +22,9 @@ from azureml.automl.dnn.vision.common.mlflow.mlflow_model_wrapper import \
 from azureml.automl.dnn.vision.common.model_export_utils import (
     _get_mlflow_signature, _get_scoring_method)
 from common_vision_utils import load_base64_images, load_fridge_dataset
+from ml_wrappers import wrap_model
 from ml_wrappers.common.constants import ModelTask
 from wrapper_validator import validate_wrapped_classification_model
-
-from ml_wrappers import wrap_model
 
 
 @pytest.mark.usefixtures('_clean_dir')

--- a/tests/automl/test_automl_image_object_detection_model_wrapper.py
+++ b/tests/automl/test_automl_image_object_detection_model_wrapper.py
@@ -16,7 +16,6 @@ import pytest
 import torch
 from azureml.automl.dnn.vision.object_detection.common.constants import \
     ModelNames
-# from azureml.automl.dnn.vision.object_detection.models import ObjectDetectionModelFactory
 from azureml.automl.dnn.vision.object_detection.models import object_detection_model_wrappers
 from azureml.automl.dnn.vision.common.mlflow.mlflow_model_wrapper import \
     MLFlowImagesModelWrapper

--- a/tests/automl/test_automl_image_object_detection_model_wrapper.py
+++ b/tests/automl/test_automl_image_object_detection_model_wrapper.py
@@ -23,10 +23,10 @@ from azureml.automl.dnn.vision.object_detection.common.constants import \
 from azureml.automl.dnn.vision.object_detection.models import \
     object_detection_model_wrappers
 from common_vision_utils import load_base64_images, load_object_fridge_dataset
+from ml_wrappers.common.constants import ModelTask
 from wrapper_validator import validate_wrapped_object_detection_model
 
 from ml_wrappers import wrap_model
-from ml_wrappers.common.constants import ModelTask
 
 
 @pytest.mark.usefixtures('_clean_dir')

--- a/tests/automl/test_automl_image_object_detection_model_wrapper.py
+++ b/tests/automl/test_automl_image_object_detection_model_wrapper.py
@@ -14,13 +14,14 @@ import azureml.automl.core.shared.constants as shared_constants
 import mlflow
 import pytest
 import torch
-from azureml.automl.dnn.vision.object_detection.common.constants import \
-    ModelNames
-from azureml.automl.dnn.vision.object_detection.models import object_detection_model_wrappers
 from azureml.automl.dnn.vision.common.mlflow.mlflow_model_wrapper import \
     MLFlowImagesModelWrapper
 from azureml.automl.dnn.vision.common.model_export_utils import (
     _get_mlflow_signature, _get_scoring_method)
+from azureml.automl.dnn.vision.object_detection.common.constants import \
+    ModelNames
+from azureml.automl.dnn.vision.object_detection.models import \
+    object_detection_model_wrappers
 from common_vision_utils import load_base64_images, load_object_fridge_dataset
 from ml_wrappers import wrap_model
 from ml_wrappers.common.constants import ModelTask
@@ -29,11 +30,16 @@ from wrapper_validator import validate_wrapped_object_detection_model
 
 @pytest.mark.usefixtures('_clean_dir')
 class TestImageModelWrapper(object):
-    # Skip for older versions of python as azureml-automl-dnn-vision works with ">=3.7,<3.9"
-    @pytest.mark.skipif(sys.version_info < (3, 7),
-                        reason='azureml-automl-dnn-vision not supported for older versions')
-    @pytest.mark.skipif(sys.version_info >= (3, 9),
-                        reason='azureml-automl-dnn-vision not supported for newer versions')
+    # Skip for older versions of python as azureml-automl-dnn-vision
+    # works with ">=3.7,<3.9"
+    @pytest.mark.skipif(
+        sys.version_info < (3, 7),
+        reason='azureml-automl-dnn-vision not supported for older versions'
+    )
+    @pytest.mark.skipif(
+        sys.version_info >= (3, 9),
+        reason='azureml-automl-dnn-vision not supported for newer versions'
+    )
     def test_wrap_automl_object_detection_model(self):
         data = load_object_fridge_dataset()[1:4]
         model_name = ModelNames.FASTER_RCNN_RESNET50_FPN
@@ -43,27 +49,36 @@ class TestImageModelWrapper(object):
             task_type = shared_constants.Tasks.IMAGE_OBJECT_DETECTION
             number_of_classes = 4
             class_names = ['can', 'carton', 'milk_bottle', 'water_bottle']
-            model_wrapper = object_detection_model_wrappers.ObjectDetectionModelFactory().get_model_wrapper(number_of_classes, model_name)
+            model_wrapper = object_detection_model_wrappers \
+                .ObjectDetectionModelFactory() \
+                .get_model_wrapper(number_of_classes, model_name)
 
             # mock for Mlflow model generation
             model_file = os.path.join(tmp_output_dir, "model.pt")
-            torch.save({
-                'model_name': model_name,
-                'number_of_classes': number_of_classes,
-                'model_state': copy.deepcopy(model_wrapper.state_dict()),
-                'specs': {
-                    'model_settings': model_wrapper.model_settings.get_settings_dict(),
-                    'inference_settings': model_wrapper.inference_settings,
-                    'classes': model_wrapper.classes,
-                    'model_specs': {
-                        'model_settings': model_wrapper.model_settings.get_settings_dict(),
+            torch.save(
+                {
+                    'model_name': model_name,
+                    'number_of_classes': number_of_classes,
+                    'model_state': copy.deepcopy(model_wrapper.state_dict()),
+                    'specs': {
+                        'model_settings':
+                        model_wrapper.model_settings.get_settings_dict(),
                         'inference_settings': model_wrapper.inference_settings,
+                        'classes': model_wrapper.classes,
+                        'model_specs': {
+                            'model_settings':
+                            model_wrapper.model_settings.get_settings_dict(),
+                            'inference_settings':
+                            model_wrapper.inference_settings,
+                        },
                     },
                 },
-
-            }, model_file)
+                model_file
+            )
             settings_file = os.path.join(
-                tmp_output_dir, shared_constants.MLFlowLiterals.MODEL_SETTINGS_FILENAME)
+                tmp_output_dir,
+                shared_constants.MLFlowLiterals.MODEL_SETTINGS_FILENAME
+            )
             remote_path = os.path.join(tmp_output_dir, "outputs")
 
             with open(settings_file, 'w') as f:
@@ -87,17 +102,22 @@ class TestImageModelWrapper(object):
                 scoring_method=_get_scoring_method(task_type)
             )
             print("Saving mlflow model at {}".format(remote_path))
-            mlflow.pyfunc.save_model(path=remote_path,
-                                     python_model=mlflow_model_wrapper,
-                                     artifacts={"model": model_file,
-                                                "settings": settings_file},
-                                     conda_env=conda_env,
-                                     signature=_get_mlflow_signature(task_type))
+            mlflow.pyfunc.save_model(
+                path=remote_path,
+                python_model=mlflow_model_wrapper,
+                artifacts={
+                    "model": model_file,
+                    "settings": settings_file
+                },
+                conda_env=conda_env,
+                signature=_get_mlflow_signature(task_type)
+            )
             mlflow_model = mlflow.pyfunc.load_model(remote_path)
 
             # load the paths as base64 images
             data = load_base64_images(data, return_image_size=True)
 
             wrapped_model = wrap_model(
-                mlflow_model, data, ModelTask.OBJECT_DETECTION, classes=class_names)
+                mlflow_model, data, ModelTask.OBJECT_DETECTION,
+                classes=class_names)
             validate_wrapped_object_detection_model(wrapped_model, data)

--- a/tests/automl/test_automl_image_object_detection_model_wrapper.py
+++ b/tests/automl/test_automl_image_object_detection_model_wrapper.py
@@ -22,9 +22,10 @@ from azureml.automl.dnn.vision.object_detection.common.constants import \
     ModelNames
 from azureml.automl.dnn.vision.object_detection.models import \
     object_detection_model_wrappers
-from common_vision_utils import load_base64_images, load_object_fridge_dataset
 from ml_wrappers import wrap_model
 from ml_wrappers.common.constants import ModelTask
+
+from common_vision_utils import load_base64_images, load_object_fridge_dataset
 from wrapper_validator import validate_wrapped_object_detection_model
 
 

--- a/tests/automl/test_automl_image_object_detection_model_wrapper.py
+++ b/tests/automl/test_automl_image_object_detection_model_wrapper.py
@@ -23,10 +23,9 @@ from azureml.automl.dnn.vision.object_detection.common.constants import \
 from azureml.automl.dnn.vision.object_detection.models import \
     object_detection_model_wrappers
 from common_vision_utils import load_base64_images, load_object_fridge_dataset
+from ml_wrappers import wrap_model
 from ml_wrappers.common.constants import ModelTask
 from wrapper_validator import validate_wrapped_object_detection_model
-
-from ml_wrappers import wrap_model
 
 
 @pytest.mark.usefixtures('_clean_dir')

--- a/tests/automl/test_automl_image_object_detection_model_wrapper.py
+++ b/tests/automl/test_automl_image_object_detection_model_wrapper.py
@@ -30,7 +30,7 @@ from wrapper_validator import validate_wrapped_object_detection_model
 
 @pytest.mark.usefixtures('_clean_dir')
 class TestImageModelWrapper(object):
-    # Skip for older versions of python as azureml-automl-dnn-vision works with ">=3.7,<3.8"
+    # Skip for older versions of python as azureml-automl-dnn-vision works with ">=3.7,<3.9"
     @pytest.mark.skipif(sys.version_info < (3, 7),
                         reason='azureml-automl-dnn-vision not supported for older versions')
     @pytest.mark.skipif(sys.version_info >= (3, 9),

--- a/tests/automl/test_automl_image_object_detection_model_wrapper.py
+++ b/tests/automl/test_automl_image_object_detection_model_wrapper.py
@@ -1,0 +1,100 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+"""Tests for wrap_model function on vision-based models"""
+
+import copy
+import json
+import os
+import sys
+import tempfile
+
+import azureml.automl.core.shared.constants as shared_constants
+import mlflow
+import pytest
+import torch
+from azureml.automl.dnn.vision.object_detection.common.constants import \
+    ModelNames
+from azureml.automl.dnn.vision.object_detection.models import ObjectDetectionModelFactory
+from azureml.automl.dnn.vision.common.mlflow.mlflow_model_wrapper import \
+    MLFlowImagesModelWrapper
+from azureml.automl.dnn.vision.common.model_export_utils import (
+    _get_mlflow_signature, _get_scoring_method)
+from common_vision_utils import load_base64_images, load_object_fridge_dataset
+from ml_wrappers import wrap_model
+from ml_wrappers.common.constants import ModelTask
+from wrapper_validator import validate_wrapped_object_detection_model
+
+
+@pytest.mark.usefixtures('_clean_dir')
+class TestImageModelWrapper(object):
+    # Skip for older versions of python as azureml-automl-dnn-vision works with ">=3.7,<3.8"
+    @pytest.mark.skipif(sys.version_info < (3, 7),
+                        reason='azureml-automl-dnn-vision not supported for older versions')
+    @pytest.mark.skipif(sys.version_info >= (3, 8),
+                        reason='azureml-automl-dnn-vision not supported for newer versions')
+    def test_wrap_automl_object_detection_model(self):
+        data = load_object_fridge_dataset()[:3]
+        model_name = ModelNames.FASTER_RCNN_RESNET50_FPN
+
+        with tempfile.TemporaryDirectory() as tmp_output_dir:
+
+            task_type = shared_constants.Tasks.IMAGE_OBJECT_DETECTION
+            number_of_classes = 4
+            model_wrapper = ObjectDetectionModelFactory().get_model_wrapper(number_of_classes, model_name)
+
+            # mock for Mlflow model generation
+            model_file = os.path.join(tmp_output_dir, "model.pt")
+            torch.save({
+                'model_name': model_name,
+                'number_of_classes': number_of_classes,
+                'model_state': copy.deepcopy(model_wrapper.state_dict()),
+                'specs': {
+                    'model_settings': model_wrapper.model_settings,
+                    'labels': model_wrapper.labels
+                },
+
+            }, model_file)
+            settings_file = os.path.join(
+                tmp_output_dir, shared_constants.MLFlowLiterals.MODEL_SETTINGS_FILENAME)
+            remote_path = os.path.join(tmp_output_dir, "outputs")
+
+            with open(settings_file, 'w') as f:
+                json.dump({}, f)
+
+            conda_env = {
+                'channels': ['conda-forge', 'pytorch'],
+                'dependencies': [
+                    'python=3.7',
+                    'numpy==1.21.6',
+                    'pytorch==1.7.1',
+                    'torchvision==0.12.0',
+                    {'pip': ['azureml-automl-dnn-vision']}
+                ],
+                'name': 'azureml-automl-dnn-vision-env'
+            }
+
+            mlflow_model_wrapper = MLFlowImagesModelWrapper(
+                model_settings={},
+                task_type=task_type,
+                scoring_method=_get_scoring_method(task_type)
+            )
+            print("Saving mlflow model at {}".format(remote_path))
+            mlflow.pyfunc.save_model(path=remote_path,
+                                     python_model=mlflow_model_wrapper,
+                                     artifacts={"model": model_file,
+                                                "settings": settings_file},
+                                     conda_env=conda_env,
+                                     signature=_get_mlflow_signature(task_type))
+            mlflow_model = mlflow.pyfunc.load_model(remote_path)
+
+            # load the paths as base64 images
+            data = load_base64_images(data)
+            wrapped_model = wrap_model(
+                mlflow_model, data, ModelTask.OBJECT_DETECTION)
+            validate_wrapped_object_detection_model(wrapped_model, data)
+
+if __name__== "__main__":
+    obj = TestImageModelWrapper()
+    obj.test_wrap_automl_object_detection_model()

--- a/tests/automl/test_automl_image_object_detection_model_wrapper.py
+++ b/tests/automl/test_automl_image_object_detection_model_wrapper.py
@@ -22,11 +22,11 @@ from azureml.automl.dnn.vision.object_detection.common.constants import \
     ModelNames
 from azureml.automl.dnn.vision.object_detection.models import \
     object_detection_model_wrappers
-from ml_wrappers import wrap_model
-from ml_wrappers.common.constants import ModelTask
-
 from common_vision_utils import load_base64_images, load_object_fridge_dataset
 from wrapper_validator import validate_wrapped_object_detection_model
+
+from ml_wrappers import wrap_model
+from ml_wrappers.common.constants import ModelTask
 
 
 @pytest.mark.usefixtures('_clean_dir')

--- a/tests/common_vision_utils.py
+++ b/tests/common_vision_utils.py
@@ -133,14 +133,18 @@ def load_images(data):
     return np.array(images)
 
 
-def get_base64_string_from_path(img_path: str, return_image_size=False) -> Union[str, Tuple[str, Tuple[int, int]]]:
+def get_base64_string_from_path(img_path: str,
+                                return_image_size: bool = False) \
+        -> Union[str, Tuple[str, Tuple[int, int]]]:
     """Load and convert pillow image to base64-encoded image
 
     :param img_path: image path
     :type img_path: str
-    :param return_image_size: true if image sizes should be returned in dataframe
+    :param return_image_size: true if image sizes should be returned in
+                            dataframe
     :type data: bool
-    :return: base64-encoded image OR a tuple containing a base64-encoded image and a tuple with the image size
+    :return: base64-encoded image OR a tuple containing a base64-encoded image
+            and a tuple with the image size
     :rtype: Union[str, Tuple[str, Tuple[int, int]]]
     """
     img = Image.open(img_path)
@@ -152,12 +156,15 @@ def get_base64_string_from_path(img_path: str, return_image_size=False) -> Union
     return img_str.decode("utf-8")
 
 
-def load_base64_images(data: pd.DataFrame, return_image_size=False) -> pd.DataFrame:
-    """Create dataframe of images encoded in base64 format (and optionally their sizes)
+def load_base64_images(data: pd.DataFrame, return_image_size: bool = False) \
+        -> pd.DataFrame:
+    """Create dataframe of images encoded in base64 format (and optionally
+        their sizes)
 
     :param data: input data with image paths and lables
     :type data: pandas.DataFrame
-    :param return_image_size: true if image sizes should be returned in dataframe
+    :param return_image_size: true if image sizes should be returned in
+                              dataframe
     :type data: bool
     :return: base64-encoded image
     :rtype: pandas.DataFrame
@@ -165,13 +172,15 @@ def load_base64_images(data: pd.DataFrame, return_image_size=False) -> pd.DataFr
     if return_image_size:
         dataset = pd.DataFrame(
             data=[[x for x in get_base64_string_from_path(
-                img_path, return_image_size=True)] for img_path in data.loc[:, IMAGE]],
+                img_path, return_image_size=True)] for img_path in
+                data.loc[:, IMAGE]],
             columns=[IMAGE, "image_size"],
         )
         return dataset
     data.loc[:, IMAGE] = data.loc[:, IMAGE].map(
         lambda img_path: get_base64_string_from_path(img_path))
     return data.loc[:, [IMAGE]]
+
 
 class ResNetPipeline(object):
     def __init__(self):

--- a/tests/common_vision_utils.py
+++ b/tests/common_vision_utils.py
@@ -138,8 +138,10 @@ def get_base64_string_from_path(img_path: str, return_image_size=False) -> Union
 
     :param img_path: image path
     :type img_path: str
-    :return: base64-encoded image
-    :rtype: str
+    :param return_image_size: true if image sizes should be returned in dataframe
+    :type data: bool
+    :return: base64-encoded image OR a tuple containing a base64-encoded image and a tuple with the image size
+    :rtype: Union[str, Tuple[str, Tuple[int, int]]]
     """
     img = Image.open(img_path)
     imgio = BytesIO()
@@ -151,10 +153,12 @@ def get_base64_string_from_path(img_path: str, return_image_size=False) -> Union
 
 
 def load_base64_images(data: pd.DataFrame, return_image_size=False) -> pd.DataFrame:
-    """Create dataframe of images encoded in base64 format
+    """Create dataframe of images encoded in base64 format (and optionally their sizes)
 
     :param data: input data with image paths and lables
     :type data: pandas.DataFrame
+    :param return_image_size: true if image sizes should be returned in dataframe
+    :type data: bool
     :return: base64-encoded image
     :rtype: pandas.DataFrame
     """

--- a/tests/common_vision_utils.py
+++ b/tests/common_vision_utils.py
@@ -7,8 +7,8 @@ import os
 import sys
 import xml.etree.ElementTree as ET
 from io import BytesIO
+from typing import Tuple, Union
 from zipfile import ZipFile
-from typing import Union, Tuple
 
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
This PR adds a wrapper for object detection models trained using azure AutoML. These models are wrapped using an MLflow wrapper and this PR adds code to process outputs from this mlflow model. The class list and size of images were additional inputs needed to ensure the outputs were standardized across the other object detection wrappers in the repo. 