### PR TITLE
Kabirwalia/add drise automl mlflow compatibility

### DIFF
--- a/python/ml_wrappers/model/image_model_wrapper.py
+++ b/python/ml_wrappers/model/image_model_wrapper.py
@@ -690,8 +690,8 @@ class MLflowDRiseWrapper():
         predictions = self._model.predict(dataset)
         return predictions
 
-    def predict(self, dataset: pd.DataFrame, iou_thresh: float = 0.005,
-                score_thresh: float = 0.1):
+    def predict(self, dataset: pd.DataFrame, iou_thresh: float = 0.25,
+                score_thresh: float = 0.5):
         """Predict the output value using the wrapped MLflow model.
 
         :param dataset: The dataset to predict on.
@@ -708,14 +708,9 @@ class MLflowDRiseWrapper():
             raise ValueError("Internal Error: Number of predictions " +
                              "does not match number of images")
 
-        print("PRINTING Num of PREDICTIONS")
-        print(len(predictions['boxes']))
-        assert len(predictions['boxes']) > 0
-        print("PRINTING One PREDICTIONS")
-        print(predictions['boxes'][0])
-        # pr = predictions['boxes'][0]
-        # for t in pr:
-        #     print(t)
+        if not len(predictions['boxes']) == 1:
+            raise ValueError(
+                "TypeError: Image needs to be a torch.Tensor or pd.DataFrame")
 
         detections = []
         for image_detections, img_size in \
@@ -724,6 +719,7 @@ class MLflowDRiseWrapper():
             raw_detections = _process_automl_detections_to_raw_detections(
                 image_detections, self._label_dict, img_size)
 
+            # TODO: check if this is needed
             # No detections found - most likely in masked image
             if raw_detections[BOXES].nelement() == 0:
                 detections.append(None)

--- a/python/ml_wrappers/model/image_model_wrapper.py
+++ b/python/ml_wrappers/model/image_model_wrapper.py
@@ -693,7 +693,7 @@ class MLflowDRiseWrapper():
         predictions = self._model.predict(dataset)
         return predictions
 
-    def predict(self, dataset: pd.DataFrame, iou_thresh: float = 0.5,
+    def predict(self, dataset: pd.DataFrame, iou_thresh: float = 0.005,
                 score_thresh: float = 0.5):
         """Predict the output value using the wrapped MLflow model.
 
@@ -714,25 +714,14 @@ class MLflowDRiseWrapper():
         detections = []
         for image_detections, img_size in \
                 zip(predictions['boxes'], image_sizes):
-            c = 0
+
             raw_detections = _process_automl_detections_to_raw_detections(
                 image_detections, self._label_dict, img_size)
 
             # No detections found - most likely in masked image
             if raw_detections[BOXES].nelement() == 0:
                 detections.append(None)
-                c = 5
-                print("HERE NOW, Five C = ", c)
                 continue
-            c += 1
-            print("One C = ", c)
-            print("NUMBER OF ELEMS IN BOXES ",
-                  raw_detections[BOXES].nelement())
-
-            print("SHAPE OF RAW DETECTIONS BOXES: ",
-                  raw_detections[BOXES].shape)
-            print("PRINTING RAW DETS BOXES")
-            print(raw_detections[BOXES])
 
             raw_detections = _apply_nms(raw_detections, iou_thresh)
             raw_detections = _filter_score(raw_detections, score_thresh)

--- a/python/ml_wrappers/model/image_model_wrapper.py
+++ b/python/ml_wrappers/model/image_model_wrapper.py
@@ -97,8 +97,6 @@ def _apply_nms(orig_prediction: dict, iou_thresh: float = 0.5):
     :return: Model prediction after nms is applied
     :rtype: dict
     """
-    print("PRINTING ORIG PRED BOXES")
-    print(orig_prediction[BOXES])
     keep = torchvision.ops.nms(orig_prediction[BOXES],
                                orig_prediction[SCORES],
                                iou_thresh)
@@ -692,8 +690,8 @@ class MLflowDRiseWrapper():
         predictions = self._model.predict(dataset)
         return predictions
 
-    def predict(self, dataset: pd.DataFrame, iou_thresh: float = 0.5,
-                score_thresh: float = 0.5):
+    def predict(self, dataset: pd.DataFrame, iou_thresh: float = 0.005,
+                score_thresh: float = 0.1):
         """Predict the output value using the wrapped MLflow model.
 
         :param dataset: The dataset to predict on.
@@ -709,6 +707,15 @@ class MLflowDRiseWrapper():
         if not len(predictions['boxes']) == len(image_sizes):
             raise ValueError("Internal Error: Number of predictions " +
                              "does not match number of images")
+
+        print("PRINTING Num of PREDICTIONS")
+        print(len(predictions['boxes']))
+        assert len(predictions['boxes']) > 0
+        print("PRINTING One PREDICTIONS")
+        print(predictions['boxes'][0])
+        # pr = predictions['boxes'][0]
+        # for t in pr:
+        #     print(t)
 
         detections = []
         for image_detections, img_size in \

--- a/python/ml_wrappers/model/image_model_wrapper.py
+++ b/python/ml_wrappers/model/image_model_wrapper.py
@@ -663,8 +663,7 @@ class MLflowDRiseWrapper():
     To be compatible with the D-RISE explainability method,
     all models must be wrapped to have the same output and input class and a
     predict function for object detection. This wrapper is customized for the
-    FasterRCNN model from Pytorch, and can also be used with the RetinaNet or
-    any other models with the same output class.
+    FasterRCNN model from AutoML.
     """
 
     def __init__(self, model: PyFuncModel,
@@ -693,7 +692,7 @@ class MLflowDRiseWrapper():
         predictions = self._model.predict(dataset)
         return predictions
 
-    def predict(self, dataset: pd.DataFrame, iou_thresh: float = 0.005,
+    def predict(self, dataset: pd.DataFrame, iou_thresh: float = 0.5,
                 score_thresh: float = 0.5):
         """Predict the output value using the wrapped MLflow model.
 

--- a/python/ml_wrappers/model/image_model_wrapper.py
+++ b/python/ml_wrappers/model/image_model_wrapper.py
@@ -185,7 +185,7 @@ def expand_class_scores(
         scores: Tensor,
         labels: Tensor,
         number_of_classes: int,
-) -> torch.Tensor:
+) -> Tensor:
     """Extrapolate a full set of class scores.
 
     Many object detection models don't return a full set of class scores, but

--- a/python/ml_wrappers/model/image_model_wrapper.py
+++ b/python/ml_wrappers/model/image_model_wrapper.py
@@ -745,7 +745,7 @@ class MLflowDRiseWrapper():
 
         if not len(predictions['boxes']) == 1:
             raise ValueError(
-                "TypeError: Image needs to be a torch.Tensor or pd.DataFrame")
+                "Currently, only 1 image can be passed to predict")
 
         detections = []
         for image_detections, img_size in \

--- a/python/ml_wrappers/model/image_model_wrapper.py
+++ b/python/ml_wrappers/model/image_model_wrapper.py
@@ -693,7 +693,7 @@ class MLflowDRiseWrapper():
         predictions = self._model.predict(dataset)
         return predictions
 
-    def predict(self, dataset: pd.DataFrame, iou_thresh: float = 0.005,
+    def predict(self, dataset: pd.DataFrame, iou_thresh: float = 0.5,
                 score_thresh: float = 0.5):
         """Predict the output value using the wrapped MLflow model.
 
@@ -714,20 +714,25 @@ class MLflowDRiseWrapper():
         detections = []
         for image_detections, img_size in \
                 zip(predictions['boxes'], image_sizes):
-
+            c = 0
             raw_detections = _process_automl_detections_to_raw_detections(
                 image_detections, self._label_dict, img_size)
+
+            # No detections found - most likely in masked image
+            if raw_detections[BOXES].nelement() == 0:
+                detections.append(None)
+                c = 5
+                print("HERE NOW, Five C = ", c)
+                continue
+            c += 1
+            print("One C = ", c)
+            print("NUMBER OF ELEMS IN BOXES ",
+                  raw_detections[BOXES].nelement())
 
             print("SHAPE OF RAW DETECTIONS BOXES: ",
                   raw_detections[BOXES].shape)
             print("PRINTING RAW DETS BOXES")
             print(raw_detections[BOXES])
-
-            # No detections found - most likely in masked image
-            if not raw_detections[BOXES].nelement() == 0:
-                detections.append([None])
-                print("HERE NOW")
-                continue
 
             raw_detections = _apply_nms(raw_detections, iou_thresh)
             raw_detections = _filter_score(raw_detections, score_thresh)

--- a/tests/automl/test_automl_image_object_detection_model_wrapper.py
+++ b/tests/automl/test_automl_image_object_detection_model_wrapper.py
@@ -133,7 +133,7 @@ class TestImageModelWrapper(object):
         reason=('azureml-automl-dnn-vision not supported ' +
                 'for newer versions of python'))
     def test_wrap_automl_object_detection_model_drise(self):
-        data = load_object_fridge_dataset()[:1]
+        data = load_object_fridge_dataset()[:2]
         model_name = ModelNames.FASTER_RCNN_RESNET50_FPN
 
         with tempfile.TemporaryDirectory() as tmp_output_dir:

--- a/tests/automl/test_automl_image_object_detection_model_wrapper.py
+++ b/tests/automl/test_automl_image_object_detection_model_wrapper.py
@@ -25,7 +25,9 @@ from azureml.automl.dnn.vision.object_detection.models import \
 from common_vision_utils import load_base64_images, load_object_fridge_dataset
 from ml_wrappers import wrap_model
 from ml_wrappers.common.constants import ModelTask
-from wrapper_validator import validate_wrapped_object_detection_model
+from ml_wrappers.model.image_model_wrapper import MLflowDRiseWrapper
+from wrapper_validator import (validate_wrapped_object_detection_model,
+                               validate_wrapped_object_detection_custom_model)
 
 
 @pytest.mark.usefixtures('_clean_dir')
@@ -121,3 +123,92 @@ class TestImageModelWrapper(object):
                 mlflow_model, data, ModelTask.OBJECT_DETECTION,
                 classes=class_names)
             validate_wrapped_object_detection_model(wrapped_model, data)
+
+    @pytest.mark.skipif(
+        sys.version_info < (3, 7),
+        reason=('azureml-automl-dnn-vision not supported ' +
+                'for older versions of python'))
+    @pytest.mark.skipif(
+        sys.version_info >= (3, 9),
+        reason=('azureml-automl-dnn-vision not supported ' +
+                'for newer versions of python'))
+    def test_wrap_automl_object_detection_model_drise(self):
+        data = load_object_fridge_dataset()[:1]
+        model_name = ModelNames.FASTER_RCNN_RESNET50_FPN
+
+        with tempfile.TemporaryDirectory() as tmp_output_dir:
+
+            task_type = shared_constants.Tasks.IMAGE_OBJECT_DETECTION
+            number_of_classes = 4
+            class_names = ['can', 'carton', 'milk_bottle', 'water_bottle']
+            model_wrapper = object_detection_model_wrappers \
+                .ObjectDetectionModelFactory() \
+                .get_model_wrapper(number_of_classes, model_name)
+
+            # mock for Mlflow model generation
+            model_file = os.path.join(tmp_output_dir, "model.pt")
+            torch.save(
+                {
+                    'model_name': model_name,
+                    'number_of_classes': number_of_classes,
+                    'model_state': copy.deepcopy(model_wrapper.state_dict()),
+                    'specs': {
+                        'model_settings':
+                        model_wrapper.model_settings.get_settings_dict(),
+                        'inference_settings': model_wrapper.inference_settings,
+                        'classes': model_wrapper.classes,
+                        'model_specs': {
+                            'model_settings':
+                            model_wrapper.model_settings.get_settings_dict(),
+                            'inference_settings':
+                            model_wrapper.inference_settings,
+                        },
+                    },
+                },
+                model_file
+            )
+            settings_file = os.path.join(
+                tmp_output_dir,
+                shared_constants.MLFlowLiterals.MODEL_SETTINGS_FILENAME
+            )
+            remote_path = os.path.join(tmp_output_dir, "outputs")
+
+            with open(settings_file, 'w') as f:
+                json.dump({}, f)
+
+            conda_env = {
+                'channels': ['conda-forge', 'pytorch'],
+                'dependencies': [
+                    'python=3.7',
+                    'numpy==1.21.6',
+                    'pytorch==1.7.1',
+                    'torchvision==0.12.0',
+                    {'pip': ['azureml-automl-dnn-vision']}
+                ],
+                'name': 'azureml-automl-dnn-vision-env'
+            }
+
+            mlflow_model_wrapper = MLFlowImagesModelWrapper(
+                model_settings={},
+                task_type=task_type,
+                scoring_method=_get_scoring_method(task_type)
+            )
+            print("Saving mlflow model at {}".format(remote_path))
+            mlflow.pyfunc.save_model(
+                path=remote_path,
+                python_model=mlflow_model_wrapper,
+                artifacts={
+                    "model": model_file,
+                    "settings": settings_file
+                },
+                conda_env=conda_env,
+                signature=_get_mlflow_signature(task_type)
+            )
+            mlflow_model = mlflow.pyfunc.load_model(remote_path)
+
+            # load the paths as base64 images
+            data = load_base64_images(data, return_image_size=True)
+
+            wrapped_model = MLflowDRiseWrapper(mlflow_model,
+                                               classes=class_names)
+            validate_wrapped_object_detection_custom_model(wrapped_model, data)

--- a/tests/automl/test_automl_image_object_detection_model_wrapper.py
+++ b/tests/automl/test_automl_image_object_detection_model_wrapper.py
@@ -26,8 +26,9 @@ from common_vision_utils import load_base64_images, load_object_fridge_dataset
 from ml_wrappers import wrap_model
 from ml_wrappers.common.constants import ModelTask
 from ml_wrappers.model.image_model_wrapper import MLflowDRiseWrapper
-from wrapper_validator import (validate_wrapped_object_detection_custom_model,
-                               validate_wrapped_object_detection_model)
+from wrapper_validator import (
+    validate_wrapped_object_detection_mlflow_drise_model,
+    validate_wrapped_object_detection_model)
 
 
 @pytest.mark.usefixtures('_clean_dir')
@@ -133,7 +134,7 @@ class TestImageModelWrapper(object):
         reason=('azureml-automl-dnn-vision not supported ' +
                 'for newer versions of python'))
     def test_wrap_automl_object_detection_model_drise(self):
-        data = load_object_fridge_dataset()[:2]
+        data = load_object_fridge_dataset()[3:4]
         model_name = ModelNames.FASTER_RCNN_RESNET50_FPN
 
         with tempfile.TemporaryDirectory() as tmp_output_dir:
@@ -211,4 +212,5 @@ class TestImageModelWrapper(object):
 
             wrapped_model = MLflowDRiseWrapper(mlflow_model,
                                                classes=class_names)
-            validate_wrapped_object_detection_custom_model(wrapped_model, data)
+            validate_wrapped_object_detection_mlflow_drise_model(
+                wrapped_model, data)

--- a/tests/automl/test_automl_image_object_detection_model_wrapper.py
+++ b/tests/automl/test_automl_image_object_detection_model_wrapper.py
@@ -26,8 +26,8 @@ from common_vision_utils import load_base64_images, load_object_fridge_dataset
 from ml_wrappers import wrap_model
 from ml_wrappers.common.constants import ModelTask
 from ml_wrappers.model.image_model_wrapper import MLflowDRiseWrapper
-from wrapper_validator import (validate_wrapped_object_detection_model,
-                               validate_wrapped_object_detection_custom_model)
+from wrapper_validator import (validate_wrapped_object_detection_custom_model,
+                               validate_wrapped_object_detection_model)
 
 
 @pytest.mark.usefixtures('_clean_dir')

--- a/tests/wrapper_validator.py
+++ b/tests/wrapper_validator.py
@@ -29,7 +29,8 @@ def validate_wrapped_object_detection_custom_model(wrapped_model, X_test):
     # validate we can call the model on the dataset
     predictions = wrapped_model.predict(X_test)
     # validate predictions and probabilities have correct shape
-    assert len(predictions) == 2
+    assert len(predictions) == 2, "Expected number of predictions to be 2." + \
+        f"Got {len(predictions)} predictions"
 
 
 def validate_wrapped_object_detection_model(wrapped_model, X_test):
@@ -86,7 +87,8 @@ def validate_wrapped_tf_model(wrapped_tf_model, X_test, model_task):
 
 def validate_wrapped_pytorch_model(wrapped_pytorch_model, X_test, model_task):
     assert isinstance(wrapped_pytorch_model, WrappedPytorchModel)
-    validate_wrapped_pred_classes_model(wrapped_pytorch_model, X_test, model_task)
+    validate_wrapped_pred_classes_model(
+        wrapped_pytorch_model, X_test, model_task)
 
 
 def validate_wrapped_pred_classes_model(wrapped_model, X_test, model_task):

--- a/tests/wrapper_validator.py
+++ b/tests/wrapper_validator.py
@@ -33,6 +33,17 @@ def validate_wrapped_object_detection_custom_model(wrapped_model, X_test):
         f"Got {len(predictions)} predictions"
 
 
+def validate_wrapped_object_detection_mlflow_drise_model(
+        wrapped_model, X_test):
+    # validate wrapped model has predict and predict_proba functions
+    function_names = [SKLearn.PREDICT]
+    validate_functions(wrapped_model, function_names)
+    # validate we can call the model on the dataset
+    predictions = wrapped_model.predict(X_test)
+    # validate predictions and probabilities have correct shape
+    assert len(predictions) == 1
+
+
 def validate_wrapped_object_detection_model(wrapped_model, X_test):
     # validate wrapped model has predict and predict_proba functions
     function_names = [SKLearn.PREDICT, SKLearn.PREDICT_PROBA]


### PR DESCRIPTION
This PR adds the MLflow DRISE wrapper for AutoML object detection models. This is required to get AutoML OD models working with DRISE in the vision explanation methods repo and working on the OD RAI Dashboard.