### PR TITLE
Update requirements-dev.txt to pin catboost below 1.2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 lightgbm
 xgboost
-catboost
+catboost<1.2
 tensorflow
 shap
 transformers<4.20.0


### PR DESCRIPTION
There was a release on May 1st which seems to have broken the build on MAC OS. Hence, pinning catboost to below 1.2.