### PR TITLE
Code quality for AutoML ML-Wrapper 

### DIFF
--- a/python/ml_wrappers/model/image_model_wrapper.py
+++ b/python/ml_wrappers/model/image_model_wrapper.py
@@ -532,10 +532,11 @@ class WrappedMlflowAutomlObjectDetectionModel:
 
         self._model = model
         self._classes = classes
-        if not (type(self._classes[0]) == str):
-            raise ValueError("classes parameter not a list of class labels")
-        self._label_dict = {label: (i+1)
-                            for i, label in enumerate(classes)}
+        try:
+            self._label_dict = {label: (i+1)
+                                for i, label in enumerate(classes)}
+        except KeyError:
+            raise KeyError("classes parameter not a list of class labels")
 
     def _mlflow_predict(self, dataset: pd.DataFrame) -> pd.DataFrame:
         """Perform the inference using the wrapped MLflow model.

--- a/python/ml_wrappers/model/image_model_wrapper.py
+++ b/python/ml_wrappers/model/image_model_wrapper.py
@@ -493,7 +493,12 @@ class WrappedMlflowAutomlObjectDetectionModel:
 
         self._model = model
         self._classes = classes
-        self._label_dict = {label: (i+1) for i, label in enumerate(classes)}
+        try:
+            assert type(self._classes[0]) == str
+            self._label_dict = {label: (i+1)
+                                for i, label in enumerate(classes)}
+        except BaseException:
+            raise ValueError("classes parameter not a list of class labels.")
 
     def _mlflow_predict(self, dataset: pd.DataFrame) -> pd.DataFrame:
         """Perform the inference using the wrapped MLflow model.

--- a/python/ml_wrappers/model/image_model_wrapper.py
+++ b/python/ml_wrappers/model/image_model_wrapper.py
@@ -532,12 +532,10 @@ class WrappedMlflowAutomlObjectDetectionModel:
 
         self._model = model
         self._classes = classes
-        try:
-            assert type(self._classes[0]) == str
-            self._label_dict = {label: (i+1)
-                                for i, label in enumerate(classes)}
-        except BaseException:
-            raise ValueError("classes parameter not a list of class labels.")
+        if not (type(self._classes[0]) == str):
+            raise ValueError("classes parameter not a list of class labels")
+        self._label_dict = {label: (i+1)
+                            for i, label in enumerate(classes)}
 
     def _mlflow_predict(self, dataset: pd.DataFrame) -> pd.DataFrame:
         """Perform the inference using the wrapped MLflow model.

--- a/python/ml_wrappers/model/image_model_wrapper.py
+++ b/python/ml_wrappers/model/image_model_wrapper.py
@@ -533,8 +533,9 @@ class WrappedMlflowAutomlObjectDetectionModel:
         self._model = model
         self._classes = classes
         try:
-            self._label_dict = {label: (i+1)
-                                for i, label in enumerate(classes)}
+            if type(classes[0] == str):
+                self._label_dict = {label: (i+1)
+                                    for i, label in enumerate(classes)}
         except KeyError:
             raise KeyError("classes parameter not a list of class labels")
 

--- a/tests/automl/test_automl_image_object_detection_model_wrapper.py
+++ b/tests/automl/test_automl_image_object_detection_model_wrapper.py
@@ -128,7 +128,7 @@ class TestImageModelWrapper(object):
             # Now test what happens when an invalid classes input is given
             label_dict = {'can': 1, 'carton': 2,
                           'milk_bottle': 3, 'water_bottle': 4}
-            with pytest.raises(TypeError):
+            with pytest.raises(ValueError):
                 wrap_model(mlflow_model,
                            data,
                            ModelTask.OBJECT_DETECTION,

--- a/tests/automl/test_automl_image_object_detection_model_wrapper.py
+++ b/tests/automl/test_automl_image_object_detection_model_wrapper.py
@@ -128,7 +128,7 @@ class TestImageModelWrapper(object):
             # Now test what happens when an invalid classes input is given
             label_dict = {'can': 1, 'carton': 2,
                           'milk_bottle': 3, 'water_bottle': 4}
-            with pytest.raises(ValueError,
+            with pytest.raises(KeyError,
                  match="classes parameter not a list of class labels"):
                 wrap_model(mlflow_model,
                            data,

--- a/tests/automl/test_automl_image_object_detection_model_wrapper.py
+++ b/tests/automl/test_automl_image_object_detection_model_wrapper.py
@@ -125,6 +125,15 @@ class TestImageModelWrapper(object):
                 classes=class_names)
             validate_wrapped_object_detection_model(wrapped_model, data)
 
+            # Now test what happens when an invalid classes input is given
+            label_dict = {'can': 1, 'carton': 2,
+                          'milk_bottle': 3, 'water_bottle': 4}
+            with pytest.raises(TypeError):
+                wrap_model(mlflow_model,
+                           data,
+                           ModelTask.OBJECT_DETECTION,
+                           class_names=label_dict)
+
     @pytest.mark.skipif(
         sys.version_info < (3, 7),
         reason=('azureml-automl-dnn-vision not supported ' +

--- a/tests/automl/test_automl_image_object_detection_model_wrapper.py
+++ b/tests/automl/test_automl_image_object_detection_model_wrapper.py
@@ -128,7 +128,8 @@ class TestImageModelWrapper(object):
             # Now test what happens when an invalid classes input is given
             label_dict = {'can': 1, 'carton': 2,
                           'milk_bottle': 3, 'water_bottle': 4}
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError("classes parameter not a list " +
+                                          "of class labels")):
                 wrap_model(mlflow_model,
                            data,
                            ModelTask.OBJECT_DETECTION,

--- a/tests/automl/test_automl_image_object_detection_model_wrapper.py
+++ b/tests/automl/test_automl_image_object_detection_model_wrapper.py
@@ -133,7 +133,7 @@ class TestImageModelWrapper(object):
                 wrap_model(mlflow_model,
                            data,
                            ModelTask.OBJECT_DETECTION,
-                           class_names=label_dict)
+                           classes=label_dict)
 
     @pytest.mark.skipif(
         sys.version_info < (3, 7),

--- a/tests/automl/test_automl_image_object_detection_model_wrapper.py
+++ b/tests/automl/test_automl_image_object_detection_model_wrapper.py
@@ -128,8 +128,8 @@ class TestImageModelWrapper(object):
             # Now test what happens when an invalid classes input is given
             label_dict = {'can': 1, 'carton': 2,
                           'milk_bottle': 3, 'water_bottle': 4}
-            with pytest.raises(ValueError("classes parameter not a list " +
-                                          "of class labels")):
+            with pytest.raises(ValueError,
+                 match="classes parameter not a list of class labels"):
                 wrap_model(mlflow_model,
                            data,
                            ModelTask.OBJECT_DETECTION,

--- a/tests/main/test_image_model_wrapper.py
+++ b/tests/main/test_image_model_wrapper.py
@@ -132,11 +132,7 @@ class TestImageModelWrapper(object):
         device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         wrapped_model = wrap_model(model.to(device),
                                    data,
-                                   ModelTask.OBJECT_DETECTION,
-                                   class_names=np.array(['can',
-                                                         'carton',
-                                                         'milk_bottle',
-                                                         'water_bottle']))
+                                   ModelTask.OBJECT_DETECTION)
         validate_wrapped_object_detection_model(wrapped_model, data)
 
     # Skip for older versions of pytorch due to missing classes
@@ -161,40 +157,23 @@ class TestImageModelWrapper(object):
         loaded_model.roi_heads.box_predictor = FastRCNNPredictor(in_features,
                                                                  5)
         device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-        label_dict = {'can': 1, 'carton': 2,
-                      'milk_bottle': 3, 'water_bottle': 4}
         wrapped_model = wrap_model(loaded_model.to(device),
                                    data,
                                    ModelTask.OBJECT_DETECTION,
-                                   class_names=label_dict)
+                                   class_names=np.array(['can',
+                                                         'carton',
+                                                         'milk_bottle',
+                                                         'water_bottle']))
         validate_wrapped_object_detection_model(wrapped_model, data)
 
-    # Skip for older versions of pytorch due to missing classes
-    @pytest.mark.skipif(sys.version_info.minor <= 6,
-                        reason='Older versions of pytorch not supported')
-    def test_automl_object_detection_model_failure(self):
-        data = load_object_fridge_dataset()[:3]
-        data = load_images(data)
-
-        mlflow.start_run(nested=True)
-
-        # Create the Faster R-CNN model
-        model = torchvision.models.detection.fasterrcnn_resnet50_fpn(
-            pretrained=True)
-
-        # Log the model
-        mlflow.pytorch.log_model(model, "fasterrcnn_resnet50_fpn")
-        loaded_model = mlflow.pytorch.load_model("fasterrcnn_resnet50_fpn")
-
-        in_features = (loaded_model.roi_heads.box_predictor
-                       .cls_score.in_features)
-        loaded_model.roi_heads.box_predictor = FastRCNNPredictor(in_features,
-                                                                 5)
-        device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+        # Now test what happens when an invalid classes input is given
+        label_dict = {'can': 1, 'carton': 2,
+                      'milk_bottle': 3, 'water_bottle': 4}
         with pytest.raises(TypeError):
             wrap_model(loaded_model.to(device),
                        data,
-                       ModelTask.OBJECT_DETECTION)
+                       ModelTask.OBJECT_DETECTION,
+                       class_names=label_dict)
 
     # Skip for older versions of pytorch due to missing classes
     @pytest.mark.skipif(sys.version_info.minor <= 6,

--- a/tests/main/test_image_model_wrapper.py
+++ b/tests/main/test_image_model_wrapper.py
@@ -6,6 +6,8 @@
 
 import sys
 
+import mlflow
+import mlflow.pytorch
 import numpy as np
 import pandas as pd
 import pytest
@@ -21,8 +23,6 @@ from common_vision_utils import (IMAGE, create_image_classification_pipeline,
 from ml_wrappers import wrap_model
 from ml_wrappers.common.constants import ModelTask
 from ml_wrappers.model.image_model_wrapper import PytorchDRiseWrapper
-import mlflow
-import mlflow.pytorch
 from wrapper_validator import (validate_wrapped_classification_model,
                                validate_wrapped_multilabel_model,
                                validate_wrapped_object_detection_custom_model,
@@ -176,7 +176,7 @@ class TestImageModelWrapper(object):
         data = load_object_fridge_dataset()[:3]
         data = load_images(data)
 
-        mlflow.start_run()
+        mlflow.start_run(nested=True)
 
         # Create the Faster R-CNN model
         model = torchvision.models.detection.fasterrcnn_resnet50_fpn(

--- a/tests/main/test_image_model_wrapper.py
+++ b/tests/main/test_image_model_wrapper.py
@@ -20,6 +20,8 @@ from common_vision_utils import (IMAGE, create_image_classification_pipeline,
 from ml_wrappers import wrap_model
 from ml_wrappers.common.constants import ModelTask
 from ml_wrappers.model.image_model_wrapper import PytorchDRiseWrapper
+import mlflow
+import mlflow.pytorch
 from wrapper_validator import (validate_wrapped_classification_model,
                                validate_wrapped_multilabel_model,
                                validate_wrapped_object_detection_custom_model,
@@ -123,8 +125,69 @@ class TestImageModelWrapper(object):
         device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         wrapped_model = wrap_model(model.to(device),
                                    data,
-                                   ModelTask.OBJECT_DETECTION)
+                                   ModelTask.OBJECT_DETECTION,
+                                   class_names=np.array(['can',
+                                                         'carton',
+                                                         'milk_bottle',
+                                                         'water_bottle']))
         validate_wrapped_object_detection_model(wrapped_model, data)
+
+    # Skip for older versions of pytorch due to missing classes
+    @pytest.mark.skipif(sys.version_info.minor <= 6,
+                        reason='Older versions of pytorch not supported')
+    def test_automl_object_detection_model_pandas(self):
+        data = load_object_fridge_dataset()[:3]
+        data = load_images(data)
+
+        mlflow.start_run()
+
+        # Create the Faster R-CNN model
+        model = torchvision.models.detection.fasterrcnn_resnet50_fpn(
+            pretrained=True)
+
+        # Log the model
+        mlflow.pytorch.log_model(model, "fasterrcnn_resnet50_fpn")
+        loaded_model = mlflow.pytorch.load_model("fasterrcnn_resnet50_fpn")
+
+        in_features = (loaded_model.roi_heads
+                       .box_predictor.cls_score.in_features)
+        loaded_model.roi_heads.box_predictor = FastRCNNPredictor(in_features,
+                                                                 5)
+        device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+        label_dict = {'can': 1, 'carton': 2,
+                      'milk_bottle': 3, 'water_bottle': 4}
+        wrapped_model = wrap_model(loaded_model.to(device),
+                                   data,
+                                   ModelTask.OBJECT_DETECTION,
+                                   class_names=label_dict)
+        validate_wrapped_object_detection_model(wrapped_model, data)
+
+    # Skip for older versions of pytorch due to missing classes
+    @pytest.mark.skipif(sys.version_info.minor <= 6,
+                        reason='Older versions of pytorch not supported')
+    def test_automl_object_detection_model_failure(self):
+        data = load_object_fridge_dataset()[:3]
+        data = load_images(data)
+
+        mlflow.start_run()
+
+        # Create the Faster R-CNN model
+        model = torchvision.models.detection.fasterrcnn_resnet50_fpn(
+            pretrained=True)
+
+        # Log the model
+        mlflow.pytorch.log_model(model, "fasterrcnn_resnet50_fpn")
+        loaded_model = mlflow.pytorch.load_model("fasterrcnn_resnet50_fpn")
+
+        in_features = (loaded_model.roi_heads.box_predictor
+                       .cls_score.in_features)
+        loaded_model.roi_heads.box_predictor = FastRCNNPredictor(in_features,
+                                                                 5)
+        device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+        with pytest.raises(TypeError):
+            wrap_model(loaded_model.to(device),
+                       data,
+                       ModelTask.OBJECT_DETECTION)
 
     # Skip for older versions of pytorch due to missing classes
     @pytest.mark.skipif(sys.version_info.minor <= 6,


### PR DESCRIPTION
Improving code quality of object detection scenario of ml-wrappers.

Adding a check for the type of classes. There is some confusion regarding the input of the classes variable, so this check ensures that classes is a list of strings representing classes. If not, a clear exception is thrown. 

According unit tests added. 

For ref - https://msdata.visualstudio.com/Vienna/_backlogs/backlog/Responsible%20AI/Epics/?workitem=2355376 