### PR TITLE
Update the python version to 3.8 in release workflows

### DIFF
--- a/.github/workflows/release-ml-wrappers.yml
+++ b/.github/workflows/release-ml-wrappers.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          python-version: 3.7
+          python-version: 3.8
 
       - if: ${{ matrix.operatingSystem != 'macos-latest' }}
         name: Install pytorch on non-MacOS


### PR DESCRIPTION
Update the python version to 3.8 in release workflows. Python 3.7 has reached end of life. Updating to 3.8.
