### PR TITLE
Pin joblib to below 1.3.0 to fix build gates

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -42,7 +42,7 @@ DEPENDENCIES = [
     'pandas<2.0.0',
     'scipy',
     'scikit-learn',
-    joblib<1.3.0; python_version <= '3.7'
+    'joblib<1.3.0; python_version <= 3.7'
 ]
 
 with open(README_FILE, 'r', encoding='utf-8') as f:

--- a/python/setup.py
+++ b/python/setup.py
@@ -41,8 +41,7 @@ DEPENDENCIES = [
     'numpy',
     'pandas<2.0.0',
     'scipy',
-    'scikit-learn',
-    'joblib<1.3.0; python_version <= 3.7'
+    'scikit-learn'
 ]
 
 with open(README_FILE, 'r', encoding='utf-8') as f:

--- a/python/setup.py
+++ b/python/setup.py
@@ -41,7 +41,8 @@ DEPENDENCIES = [
     'numpy',
     'pandas<2.0.0',
     'scipy',
-    'scikit-learn'
+    'scikit-learn',
+    joblib<1.3.0; python_version <= '3.7'
 ]
 
 with open(README_FILE, 'r', encoding='utf-8') as f:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ raiutils
 fastai
 vision_explanation_methods
 mlflow
+joblib<1.3.0; python_version <= '3.7'


### PR DESCRIPTION
Similar failure seen as in PR https://github.com/microsoft/responsible-ai-toolbox/pull/2155. So fixing this by pinning joblib in requirement-dev.txt.