### PR TITLE
Improve run time performance of prediction wrappers

### DIFF
--- a/python/ml_wrappers/model/predictions_wrapper.py
+++ b/python/ml_wrappers/model/predictions_wrapper.py
@@ -26,7 +26,7 @@ class PredictionsModelWrapper:
         :param y_pred: Predictions of the model.
         :type y_pred: np.ndarray
         :param should_construct_pandas_query: Whether to use pandas query()
-            function to filter the data. If set to False, the data will 
+            function to filter the data. If set to False, the data will
             be filtered using iloc(). Defaults to True.
         :type should_construct_pandas_query: Optional[bool]
         """
@@ -52,7 +52,7 @@ class PredictionsModelWrapper:
         :type query_test_data_row: pd.DataFrame
         :return: The filtered dataframe based on the values in query data.
         :rtype: pd.DataFrame
-        """        
+        """
         if self._should_construct_pandas_query:
             data_copy = self._combined_data
             for column_name, column_data in query_test_data_row.squeeze().items():
@@ -133,7 +133,7 @@ class PredictionsModelWrapperRegression(PredictionsModelWrapper):
         :param y_pred: Predictions of the model.
         :type y_pred: np.ndarray
         :param should_construct_pandas_query: Whether to use pandas query()
-            function to filter the data. If set to False, the data will 
+            function to filter the data. If set to False, the data will
             be filtered using iloc(). Defaults to True.
         :type should_construct_pandas_query: Optional[bool]
         """
@@ -157,7 +157,7 @@ class PredictionsModelWrapperClassification(PredictionsModelWrapper):
         :param y_pred_proba: Prediction probabilities of the model.
         :type y_pred_proba: np.ndarray
         :param should_construct_pandas_query: Whether to use pandas query()
-            function to filter the data. If set to False, the data will 
+            function to filter the data. If set to False, the data will
             be filtered using iloc(). Defaults to True.
         :type should_construct_pandas_query: Optional[bool]
         """

--- a/python/ml_wrappers/model/predictions_wrapper.py
+++ b/python/ml_wrappers/model/predictions_wrapper.py
@@ -53,7 +53,7 @@ class PredictionsModelWrapper:
         :return: The filtered dataframe based on the values in query data.
         :rtype: pd.DataFrame
         """
-        if self._should_construct_pandas_query:
+        if not self._should_construct_pandas_query:
             data_copy = self._combined_data
             for column_name, column_data in query_test_data_row.squeeze().items():
                 data_copy = data_copy[data_copy[column_name] == column_data]

--- a/python/ml_wrappers/model/predictions_wrapper.py
+++ b/python/ml_wrappers/model/predictions_wrapper.py
@@ -17,13 +17,18 @@ class PredictionsModelWrapper:
     and the predictions of the model. This wrapper is useful when
     it is not possible to load the model.
     """
-    def __init__(self, test_data: pd.DataFrame, y_pred: np.ndarray):
+    def __init__(self, test_data: pd.DataFrame, y_pred: np.ndarray,
+                 should_construct_pandas_query: Optional[bool] = True):
         """Creates a PredictionsModelWrapper object.
 
         :param test_data: The data that was used to train the model.
         :type test_data: pd.DataFrame
         :param y_pred: Predictions of the model.
         :type y_pred: np.ndarray
+        :param should_construct_pandas_query: Whether to use pandas query()
+            function to filter the data. If set to False, the data will 
+            be filtered using iloc(). Defaults to True.
+        :type should_construct_pandas_query: Optional[bool]
         """
         if not isinstance(test_data, pd.DataFrame):
             raise DataValidationException(
@@ -37,6 +42,7 @@ class PredictionsModelWrapper:
                 "do not match with number of predictions")
         self._combined_data = test_data.copy()
         self._combined_data[TARGET] = y_pred
+        self._should_construct_pandas_query = should_construct_pandas_query
 
     def _get_filtered_data(
             self, query_test_data_row: pd.DataFrame) -> pd.DataFrame:
@@ -46,18 +52,24 @@ class PredictionsModelWrapper:
         :type query_test_data_row: pd.DataFrame
         :return: The filtered dataframe based on the values in query data.
         :rtype: pd.DataFrame
-        """
-        queries = []
-        for column_name, column_data in query_test_data_row.squeeze().items():
-            if isinstance(column_data, str):
-                queries.append("`{}` == '{}'".format(
-                    column_name, column_data))
-            else:
-                queries.append("`{}` == {}".format(
-                    column_name, column_data))
+        """        
+        if self._should_construct_pandas_query:
+            data_copy = self._combined_data
+            for column_name, column_data in query_test_data_row.squeeze().items():
+                data_copy = data_copy[data_copy[column_name] == column_data]
+            filtered_df = data_copy
+        else:
+            queries = []
+            for column_name, column_data in query_test_data_row.squeeze().items():
+                if isinstance(column_data, str):
+                    queries.append("`{}` == '{}'".format(
+                        column_name, column_data))
+                else:
+                    queries.append("`{}` == {}".format(
+                        column_name, column_data))
 
-        queries_str = '(' + ') & ('.join(queries) + ')'
-        filtered_df = self._combined_data.query(queries_str)
+            queries_str = '(' + ') & ('.join(queries) + ')'
+            filtered_df = self._combined_data.query(queries_str)
 
         if len(filtered_df) == 0:
             raise EmptyDataException(
@@ -93,6 +105,7 @@ class PredictionsModelWrapper:
         :type state: Dict
         """
         self._combined_data = state["_combined_data"]
+        self._should_construct_pandas_query = state["_should_construct_pandas_query"]
 
     def __getstate__(self):
         """Return the state so that the wrapped model is
@@ -103,6 +116,7 @@ class PredictionsModelWrapper:
         """
         state = {}
         state["_combined_data"] = self._combined_data
+        state["_should_construct_pandas_query"] = self._should_construct_pandas_query
         return state
 
 
@@ -110,16 +124,21 @@ class PredictionsModelWrapperRegression(PredictionsModelWrapper):
     """Model wrapper to wrap the samples used to train the models
     and the predictions of the model for regression tasks.
     """
-    def __init__(self, test_data: pd.DataFrame, y_pred: np.ndarray):
+    def __init__(self, test_data: pd.DataFrame, y_pred: np.ndarray,
+                 should_construct_pandas_query: Optional[bool] = True):
         """Creates a PredictionsModelWrapperRegression object.
 
         :param test_data: The data that was used to train the model.
         :type test_data: pd.DataFrame
         :param y_pred: Predictions of the model.
         :type y_pred: np.ndarray
+        :param should_construct_pandas_query: Whether to use pandas query()
+            function to filter the data. If set to False, the data will 
+            be filtered using iloc(). Defaults to True.
+        :type should_construct_pandas_query: Optional[bool]
         """
         super(PredictionsModelWrapperRegression, self).__init__(
-            test_data, y_pred)
+            test_data, y_pred, should_construct_pandas_query)
 
 
 class PredictionsModelWrapperClassification(PredictionsModelWrapper):
@@ -127,7 +146,8 @@ class PredictionsModelWrapperClassification(PredictionsModelWrapper):
     and the predictions of the model for classification tasks.
     """
     def __init__(self, test_data: pd.DataFrame, y_pred: np.ndarray,
-                 y_pred_proba: Optional[np.ndarray] = None):
+                 y_pred_proba: Optional[np.ndarray] = None,
+                 should_construct_pandas_query: Optional[bool] = True):
         """Creates a PredictionsModelWrapperClassification object.
 
         :param test_data: The data that was used to train the model.
@@ -136,9 +156,13 @@ class PredictionsModelWrapperClassification(PredictionsModelWrapper):
         :type y_pred: np.ndarray
         :param y_pred_proba: Prediction probabilities of the model.
         :type y_pred_proba: np.ndarray
+        :param should_construct_pandas_query: Whether to use pandas query()
+            function to filter the data. If set to False, the data will 
+            be filtered using iloc(). Defaults to True.
+        :type should_construct_pandas_query: Optional[bool]
         """
         super(PredictionsModelWrapperClassification, self).__init__(
-            test_data, y_pred)
+            test_data, y_pred, should_construct_pandas_query)
         self._num_classes = None
         if y_pred_proba is not None:
             if not isinstance(y_pred_proba, np.ndarray):

--- a/tests/main/test_predictions_wrapper.py
+++ b/tests/main/test_predictions_wrapper.py
@@ -35,12 +35,12 @@ class TestPredictionsWrapper:
         if hasattr(new_model_wrapper, "predict_proba"):
             self.verify_predict_proba_outputs(model, new_model_wrapper, test_data)
 
-
+@pytest.mark.parametrize('should_construct_pandas_query', [True, False])
 class TestPredictionsWrapperClassification(TestPredictionsWrapper):
     @pytest.mark.parametrize('dataset_name', ['iris', 'titanic', 'cancer', 'wine', 'multiclass'])
     def test_prediction_wrapper_classification(
             self, iris, titanic_simple, cancer, cancer_booleans, wine,
-            multiclass_classification, dataset_name):
+            multiclass_classification, dataset_name, should_construct_pandas_query):
         dataset_to_fixture_dict = {
            'iris': iris,
            'titanic': titanic_simple,
@@ -71,13 +71,15 @@ class TestPredictionsWrapperClassification(TestPredictionsWrapper):
         model_predict_proba = model.predict_proba(X_test)
 
         model_wrapper = PredictionsModelWrapperClassification(
-            X_test, model_predict, model_predict_proba)
+            X_test, model_predict, model_predict_proba,
+            should_construct_pandas_query=should_construct_pandas_query)
 
         self.verify_predict_outputs(model, model_wrapper, X_test)
         self.verify_predict_proba_outputs(model, model_wrapper, X_test)
         self.verify_pickle_serialization(model, model_wrapper, X_test)
 
-    def test_prediction_wrapper_unsupported_scenarios(self, iris):
+    def test_prediction_wrapper_unsupported_scenarios(
+            self, iris, should_construct_pandas_query):
         dataset = iris
         X_train = pd.DataFrame(data=dataset[DatasetConstants.X_TRAIN],
                                columns=dataset[DatasetConstants.FEATURES])
@@ -93,21 +95,24 @@ class TestPredictionsWrapperClassification(TestPredictionsWrapper):
                 DataValidationException,
                 match="Expecting a pandas dataframe for test_data"):
             PredictionsModelWrapperClassification(
-                X_test.values, model_predict, model_predict_proba
+                X_test.values, model_predict, model_predict_proba,
+                should_construct_pandas_query=should_construct_pandas_query
             )
 
         with pytest.raises(
                 DataValidationException,
                 match="Expecting a numpy array for y_pred"):
             PredictionsModelWrapperClassification(
-                X_test, model_predict.tolist(), model_predict_proba
+                X_test, model_predict.tolist(), model_predict_proba,
+                should_construct_pandas_query=should_construct_pandas_query
             )
 
         with pytest.raises(
                 DataValidationException,
                 match="Expecting a numpy array for y_pred_proba"):
             PredictionsModelWrapperClassification(
-                X_test, model_predict, model_predict_proba.tolist()
+                X_test, model_predict, model_predict_proba.tolist(),
+                should_construct_pandas_query=should_construct_pandas_query
             )
 
         with pytest.raises(
@@ -115,7 +120,8 @@ class TestPredictionsWrapperClassification(TestPredictionsWrapper):
                 match="The number of instances in test data "
                       "do not match with number of predictions"):
             PredictionsModelWrapperClassification(
-                X_test.iloc[0:len(X_test) - 1], model_predict, model_predict_proba
+                X_test.iloc[0:len(X_test) - 1], model_predict, model_predict_proba,
+                should_construct_pandas_query=should_construct_pandas_query
             )
 
         with pytest.raises(
@@ -123,10 +129,11 @@ class TestPredictionsWrapperClassification(TestPredictionsWrapper):
                 match="The number of instances in test data "
                       "do not match with number of prediction probabilities"):
             PredictionsModelWrapperClassification(
-                X_test.iloc[0:len(X_test) - 1], model_predict[0:len(X_test) - 1], model_predict_proba
+                X_test.iloc[0:len(X_test) - 1], model_predict[0:len(X_test) - 1], model_predict_proba,
+                should_construct_pandas_query=should_construct_pandas_query
             )
 
-    def test_prediction_wrapper_unsupported_predict_scenarios(self, iris):
+    def test_prediction_wrapper_unsupported_predict_scenarios(self, iris, should_construct_pandas_query):
         dataset = iris
         X_train = pd.DataFrame(data=dataset[DatasetConstants.X_TRAIN],
                                columns=dataset[DatasetConstants.FEATURES])
@@ -139,7 +146,8 @@ class TestPredictionsWrapperClassification(TestPredictionsWrapper):
         model_predict_proba = model.predict_proba(X_test)
 
         model_wrapper = PredictionsModelWrapperClassification(
-            X_test, model_predict, model_predict_proba)
+            X_test, model_predict, model_predict_proba,
+            should_construct_pandas_query=should_construct_pandas_query)
         with pytest.raises(
                 DataValidationException,
                 match="Expecting a pandas dataframe for query_test_data"):
@@ -156,7 +164,8 @@ class TestPredictionsWrapperClassification(TestPredictionsWrapper):
                 match="Model wrapper configured without prediction probabilities"):
             model_wrapper_without_predict_proba.predict_proba(X_test)
 
-    def test_prediction_wrapper_unseen_data_predict_scenarios(self, iris):
+    def test_prediction_wrapper_unseen_data_predict_scenarios(
+            self, iris, should_construct_pandas_query):
         dataset = iris
         X_train = pd.DataFrame(data=dataset[DatasetConstants.X_TRAIN],
                                columns=dataset[DatasetConstants.FEATURES])
@@ -169,7 +178,8 @@ class TestPredictionsWrapperClassification(TestPredictionsWrapper):
         model_predict_proba = model.predict_proba(X_test[0:len(X_test) - 1])
 
         model_wrapper = PredictionsModelWrapperClassification(
-            X_test[0:len(X_test) - 1], model_predict, model_predict_proba)
+            X_test[0:len(X_test) - 1], model_predict, model_predict_proba,
+            should_construct_pandas_query=should_construct_pandas_query)
 
         with pytest.raises(
                 EmptyDataException,
@@ -182,9 +192,12 @@ class TestPredictionsWrapperClassification(TestPredictionsWrapper):
             model_wrapper.predict_proba(X_test[len(X_test) - 1:len(X_test)])
 
 
+@pytest.mark.parametrize('should_construct_pandas_query', [True, False])
 class TestPredictionsWrapperRegression(TestPredictionsWrapper):
     @pytest.mark.parametrize('dataset_name', ['housing', 'energy', 'diabetes'])
-    def test_prediction_wrapper_regression(self, dataset_name, housing, energy, diabetes):
+    def test_prediction_wrapper_regression(
+            self, should_construct_pandas_query,
+            dataset_name, housing, energy, diabetes):
         dataset_to_fixture_dict = {
            'housing': housing,
            'energy': energy,
@@ -203,8 +216,30 @@ class TestPredictionsWrapperRegression(TestPredictionsWrapper):
         model_predict = model.predict(X_test)
 
         model_wrapper = PredictionsModelWrapperRegression(
-            X_test, model_predict)
+            X_test, model_predict,
+            should_construct_pandas_query=should_construct_pandas_query)
 
         self.verify_predict_outputs(model, model_wrapper, X_test)
         assert not hasattr(model_wrapper, "predict_proba")
         self.verify_pickle_serialization(model, model_wrapper, X_test)
+
+    @pytest.mark.parametrize('len', [10, 100, 200, 300, 400, 500, 1000])
+    def test_prediction_wrapper_regression_perf(self, housing, len, should_construct_pandas_query):
+        dataset = housing
+
+        X_train = pd.DataFrame(data=dataset[DatasetConstants.X_TRAIN],
+                               columns=dataset[DatasetConstants.FEATURES])
+        X_test = pd.DataFrame(data=dataset[DatasetConstants.X_TEST],
+                              columns=dataset[DatasetConstants.FEATURES])
+
+        y_train = dataset[DatasetConstants.Y_TRAIN]
+        model = create_lightgbm_regressor(X_train, y_train)
+
+        model_predict = model.predict(X_test[0:len])
+
+        model_wrapper = PredictionsModelWrapperRegression(
+            X_test[0:len], model_predict, should_construct_pandas_query=should_construct_pandas_query)
+
+        self.verify_predict_outputs(model, model_wrapper, X_test[0:len])
+        assert not hasattr(model_wrapper, "predict_proba")
+        self.verify_pickle_serialization(model, model_wrapper, X_test[0:len])

--- a/tests/main/test_predictions_wrapper.py
+++ b/tests/main/test_predictions_wrapper.py
@@ -35,6 +35,7 @@ class TestPredictionsWrapper:
         if hasattr(new_model_wrapper, "predict_proba"):
             self.verify_predict_proba_outputs(model, new_model_wrapper, test_data)
 
+
 @pytest.mark.parametrize('should_construct_pandas_query', [True, False])
 class TestPredictionsWrapperClassification(TestPredictionsWrapper):
     @pytest.mark.parametrize('dataset_name', ['iris', 'titanic', 'cancer', 'wine', 'multiclass'])

--- a/tests/main/test_predictions_wrapper.py
+++ b/tests/main/test_predictions_wrapper.py
@@ -224,8 +224,8 @@ class TestPredictionsWrapperRegression(TestPredictionsWrapper):
         assert not hasattr(model_wrapper, "predict_proba")
         self.verify_pickle_serialization(model, model_wrapper, X_test)
 
-    @pytest.mark.parametrize('len', [10, 100, 200, 300, 400, 500, 1000])
-    def test_prediction_wrapper_regression_perf(self, housing, len, should_construct_pandas_query):
+    @pytest.mark.parametrize('length_test_set', [10, 100, 200, 300, 400, 500, 1000])
+    def test_prediction_wrapper_regression_perf(self, housing, length_test_set, should_construct_pandas_query):
         dataset = housing
 
         X_train = pd.DataFrame(data=dataset[DatasetConstants.X_TRAIN],
@@ -236,11 +236,11 @@ class TestPredictionsWrapperRegression(TestPredictionsWrapper):
         y_train = dataset[DatasetConstants.Y_TRAIN]
         model = create_lightgbm_regressor(X_train, y_train)
 
-        model_predict = model.predict(X_test[0:len])
+        model_predict = model.predict(X_test[0:length_test_set])
 
         model_wrapper = PredictionsModelWrapperRegression(
-            X_test[0:len], model_predict, should_construct_pandas_query=should_construct_pandas_query)
+            X_test[0:length_test_set], model_predict, should_construct_pandas_query=should_construct_pandas_query)
 
-        self.verify_predict_outputs(model, model_wrapper, X_test[0:len])
+        self.verify_predict_outputs(model, model_wrapper, X_test[0:length_test_set])
         assert not hasattr(model_wrapper, "predict_proba")
-        self.verify_pickle_serialization(model, model_wrapper, X_test[0:len])
+        self.verify_pickle_serialization(model, model_wrapper, X_test[0:length_test_set])


### PR DESCRIPTION
The pandas `query()` function is slow to find records with specific values. More on efficiently searching the pandas dataframe at [link](https://docs.kanaries.net/tutorials/Pandas/pandas-search-value-column).

The proposed solution is to use `iloc()` function is pandas. The time taken using `iloc()` is better than pandas `query()` function.

| Rows | Search time using query() (sec) | Search time using iloc() (sec) |
|----------|----------|----------|
| 10   | 0.46  | 0.46 |
| 100   | 1.98  | 1.43  |
| 200   |3.73  | 1.77  |
| 300   | 4.54  | 2.50  |
| 400   | 5.71  | 2.65  |
| 500   | 4.51  | 2.78 |
| 1000   | 9.20  | 5.70  |
| 2000   | 26.63 |13.39  |
| 3000   | 35.02  | 16.93 |
| 4000   | 43.87  | 22.60  |
| 5000   | 43.94  | 28.84  |
