### PR TITLE
add openai model endpoint wrapper

### DIFF
--- a/python/ml_wrappers/model/__init__.py
+++ b/python/ml_wrappers/model/__init__.py
@@ -6,12 +6,13 @@
 
 from .endpoint_wrapper import EndpointWrapperModel
 from .model_wrapper import _wrap_model, wrap_model
+from .openai_wrapper import OpenaiWrapperModel
 from .pytorch_wrapper import WrappedPytorchModel
 from .tensorflow_wrapper import WrappedTensorflowModel, is_sequential
 from .wrapped_classification_model import WrappedClassificationModel
 from .wrapped_regression_model import WrappedRegressionModel
 
-__all__ = ['EndpointWrapperModel', 'WrappedClassificationModel',
-           'WrappedPytorchModel', 'WrappedRegressionModel',
-           'WrappedTensorflowModel', '_wrap_model',
-           'is_sequential', 'wrap_model']
+__all__ = ['EndpointWrapperModel', 'OpenaiWrapperModel',
+           'WrappedClassificationModel', 'WrappedPytorchModel',
+           'WrappedRegressionModel', 'WrappedTensorflowModel',
+           '_wrap_model', 'is_sequential', 'wrap_model']

--- a/python/ml_wrappers/model/openai_wrapper.py
+++ b/python/ml_wrappers/model/openai_wrapper.py
@@ -1,0 +1,190 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+"""Defines a model wrapper for an openai model endpoint."""
+
+import numpy as np
+
+try:
+    import openai
+    openai_installed = True
+except ImportError:
+    openai_installed = False
+try:
+    from raiutils.common.retries import retry_function
+    rai_utils_installed = True
+except ImportError:
+    rai_utils_installed = False
+
+
+CONTENT = 'content'
+
+
+def replace_backtick_chars(message):
+    """Replace backtick characters in a message.
+
+    :param message: The message.
+    :type message: str
+    :return: The message with backtick characters replaced.
+    :rtype: str
+    """
+    return message.replace('`', '')
+
+
+class ChatCompletion(object):
+    """A class to call the openai chat completion endpoint."""
+
+    def __init__(self, messages, engine, temperature,
+                 max_tokens, top_p, frequency_penalty,
+                 presence_penalty, stop):
+        """Initialize the class.
+
+        :param messages: The messages.
+        :type messages: list
+        :param engine: The engine.
+        :type engine: str
+        :param temperature: The temperature.
+        :type temperature: float
+        :param max_tokens: The maximum number of tokens.
+        :type max_tokens: int
+        :param top_p: The top p.
+        :type top_p: float
+        :param frequency_penalty: The frequency penalty.
+        :type frequency_penalty: float
+        :param presence_penalty: The presence penalty.
+        :type presence_penalty: float
+        :param stop: The stop.
+        :type stop: list
+        """
+        self.messages = messages
+        self.engine = engine
+        self.temperature = temperature
+        self.max_tokens = max_tokens
+        self.top_p = top_p
+        self.frequency_penalty = frequency_penalty
+        self.presence_penalty = presence_penalty
+        self.stop = stop
+
+    def fetch(self):
+        """Call the openai chat completion endpoint.
+
+        :return: The response.
+        :rtype: dict
+        """
+        return openai.ChatCompletion.create(
+            engine=self.engine,
+            messages=self.messages,
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+            top_p=self.top_p,
+            frequency_penalty=self.frequency_penalty,
+            presence_penalty=self.presence_penalty,
+            stop=self.stop)
+
+
+class OpenaiWrapperModel(object):
+    """A model wrapper for an openai model endpoint."""
+
+    def __init__(self, api_type, api_base, api_version, api_key,
+                 engine="gpt-4-32k", temperature=0.7, max_tokens=800,
+                 top_p=0.95, frequency_penalty=0, presence_penalty=0,
+                 stop=None):
+        """Initialize the model.
+
+        :param api_type: The type of the API.
+        :type api_type: str
+        :param api_base: The base URL for the API.
+        :type api_base: str
+        :param api_version: The version of the API.
+        :type api_version: str
+        :param api_key: The API key.
+        :type api_key: str
+        :param engine: The engine.
+        :type engine: str
+        :param temperature: The temperature.
+        :type temperature: float
+        :param max_tokens: The maximum number of tokens.
+        :type max_tokens: int
+        :param top_p: The top p.
+        :type top_p: float
+        :param frequency_penalty: The frequency penalty.
+        :type frequency_penalty: float
+        :param presence_penalty: The presence penalty.
+        :type presence_penalty: float
+        :param stop: The stop.
+        :type stop: list
+        """
+        self.api_type = api_type
+        self.api_base = api_base
+        self.api_version = api_version
+        self.api_key = api_key
+        self.engine = engine
+        self.temperature = temperature
+        self.max_tokens = max_tokens
+        self.top_p = top_p
+        self.frequency_penalty = frequency_penalty
+        self.presence_penalty = presence_penalty
+        self.stop = stop
+
+    def _call_webservice(self, data):
+        """Common code to call the webservice.
+
+        :param data: The data to send to the webservice.
+        :type data: pandas.DataFrame or list
+        :return: The result.
+        :rtype: numpy.ndarray
+        """
+        if not rai_utils_installed:
+            error = "raiutils package is required to call openai endpoint"
+            raise RuntimeError(error)
+        if not openai_installed:
+            error = "openai package is required to call openai endpoint"
+            raise RuntimeError(error)
+        if not isinstance(data, list):
+            if isinstance(data, np.ndarray):
+                data = data.tolist()
+            else:
+                data = data.values.tolist()
+        openai.api_type = self.api_type
+        openai.api_base = self.api_base
+        openai.api_version = self.api_version
+        openai.api_key = self.api_key
+        answers = []
+        for doc in data:
+            messages = []
+            messages.append({'role': 'user', CONTENT: doc})
+            fetcher = ChatCompletion(messages, self.engine, self.temperature,
+                                     self.max_tokens, self.top_p,
+                                     self.frequency_penalty,
+                                     self.presence_penalty, self.stop)
+            action_name = "Call openai chat completion"
+            err_msg = "Failed to call openai endpoint"
+            max_retries = 4
+            retry_delay = 60
+            response = retry_function(fetcher.fetch, action_name, err_msg,
+                                      max_retries=max_retries,
+                                      retry_delay=retry_delay)
+            answers.append(replace_backtick_chars(response['choices'][0]['message'][CONTENT]))
+        return np.array(answers)
+
+    def predict(self, context, model_input=None):
+        """Predict using the model.
+
+        :param context: The context for MLFlow model or the input data.
+        :type context: mlflow.pyfunc.model.PythonModelContext or
+            pandas.DataFrame
+        :param model_input: The input to the model.
+        :type model_input: pandas.DataFrame
+        :return: The predictions.
+        :rtype: numpy.ndarray
+        """
+        # This is to conform to the scikit-learn API format
+        # which MLFlow does not follow
+        if model_input is None:
+            model_input = context
+        questions = model_input['questions']
+        if isinstance(questions, str):
+            questions = [questions]
+        result = self._call_webservice(questions)
+        return result

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,3 +11,4 @@ vision_explanation_methods
 mlflow
 joblib<1.3.0; python_version <= '3.7'
 scikeras
+openai; python_version >= '3.7'

--- a/tests/main/test_openai_wrapper.py
+++ b/tests/main/test_openai_wrapper.py
@@ -1,0 +1,80 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+"""Tests the EndpointWrapperModel class."""
+
+import sys
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+from ml_wrappers.model import OpenaiWrapperModel
+
+
+@pytest.mark.usefixtures('_clean_dir')
+class TestOpenaiWrapperModel(object):
+    @pytest.mark.skipif(sys.version_info.minor <= 6,
+                        reason='Openai not supported for older versions')
+    def test_predict_call(self):
+        # test creating the OpenaiWrapperModel and
+        # calling the predict function
+        api_type = "azure"
+        api_base = "https://mock.openai.azure.com/"
+        api_version = "2023-03-15-preview"
+        api_key = "mock"
+        context = ''
+        questions = "How to convert 10^9/l to liter?"
+        answer = (' It seems there is some confusion with the units being' +
+                  ' used in your question. The symbol `10^9/l` is often' +
+                  ' used to represent a concentration of 10^9 molecules' +
+                  ' or particles per liter of a solution. However, it is' +
+                  ' not a unit of volume and cannot be directly converted' +
+                  ' to liters. If you are trying to convert a concentration' +
+                  ' from one unit to another, such as from micrograms per' +
+                  ' liter (µg/L) to milligrams per liter (mg/L), you can' +
+                  ' use the appropriate conversion factor. For example,' +
+                  ' 1 µg/L is equal to 0.001 mg/L. If you need help' +
+                  ' with a specific conversion, please provide more' +
+                  ' details and I will do my best to assist you.')
+        test_data = pd.DataFrame(data=[[context, questions, answer]],
+                                 columns=['context', 'questions', 'answer'])
+        mock_result = {
+            "id": "chatcmpl-XYZ",
+            "object": "chat.completion",
+            "created": 123,
+            "model": "gpt-4-32k",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "message": {
+                        "role": "assistant",
+                        "content": ('To convert from 10^9 per liter to ' +
+                                    'liters, you need to find the ' +
+                                    'reciprocal of the given value.' +
+                                    '\n\nReciprocal of 10^9 per ' +
+                                    'liter = 1 / (10^9 per liter)' +
+                                    '\n\nSo, the value in liters ' +
+                                    'is 1 / 10^9 liters, or ' +
+                                    '10^(-9) liters.')
+                    }
+                }
+            ],
+            "usage": {
+                "completion_tokens": 69,
+                "prompt_tokens": 18,
+                "total_tokens": 87
+            }
+        }
+        openai_model = OpenaiWrapperModel(
+            api_type, api_base, api_version, api_key)
+        # mock the openai.ChatCompletion.create function
+        with patch('openai.ChatCompletion.create') as mock_create:
+            # wrap return value in mock class with read method
+            mock_create.return_value = mock_result
+            context = {}
+            result = openai_model.predict(context, test_data)
+            expected_result = mock_result["choices"][0]["message"]["content"]
+            assert len(result) == 1
+            assert result[0] == expected_result


### PR DESCRIPTION
Add openai model endpoint wrapper.  This includes the wrapper around an azure openai API, the retry logic to attempt calling the API multiple times incase of network flakiness, and logic to re-wrap the model's output as a pandas dataframe.