### PR TITLE
migrate tests to KerasClassifier and KerasRegressor from scikeras since tensorflow has removed them to fix builds

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ fastai
 vision_explanation_methods
 mlflow
 joblib<1.3.0; python_version <= '3.7'
+scikeras

--- a/tests/common_utils.py
+++ b/tests/common_utils.py
@@ -33,12 +33,11 @@ except ImportError:
     pass
 
 try:
+    from scikeras.wrappers import KerasClassifier, KerasRegressor
     from tensorflow import keras
     from tensorflow.keras import Input, Model
     from tensorflow.keras.layers import Activation, Dense, Dropout, concatenate
     from tensorflow.keras.models import Sequential
-    from tensorflow.keras.wrappers.scikit_learn import (KerasClassifier,
-                                                        KerasRegressor)
 except (ImportError, TypeError):
     pass
 
@@ -305,9 +304,9 @@ def create_scikit_keras_model_func(feature_number, num_classes=None):
                           metrics=['accuracy'])
         else:
             model.add(Dense(num_classes, activation=Activation('softmax')))
-            model.compile(loss=keras.losses.categorical_crossentropy,
+            model.compile(loss=keras.losses.sparse_categorical_crossentropy,
                           optimizer=keras.optimizers.Adadelta(),
-                          metrics=['accuracy'])
+                          metrics=['sparse_categorical_accuracy'])
         return model
     return common_scikit_keras_model
 
@@ -317,7 +316,7 @@ def create_scikit_keras_regressor(X, y):
     batch_size = 500
     epochs = 10
     model_func = create_scikit_keras_model_func(X.shape[1])
-    model = KerasRegressor(build_fn=model_func, nb_epoch=epochs, batch_size=batch_size, verbose=1)
+    model = KerasRegressor(model=model_func, epochs=epochs, batch_size=batch_size, verbose=1)
     model.fit(X, y)
     return model
 
@@ -327,7 +326,7 @@ def create_scikit_keras_binary_classifier(X, y):
     batch_size = 500
     epochs = 10
     model_func = create_scikit_keras_model_func(X.shape[1], num_classes=2)
-    model = KerasClassifier(build_fn=model_func, nb_epoch=epochs, batch_size=batch_size, verbose=1)
+    model = KerasClassifier(model=model_func, epochs=epochs, batch_size=batch_size, verbose=1)
     model.fit(X, y)
     return model
 
@@ -338,7 +337,7 @@ def create_scikit_keras_multiclass_classifier(X, y):
     epochs = 10
     num_classes = len(np.unique(y))
     model_func = create_scikit_keras_model_func(X.shape[1], num_classes=num_classes)
-    model = KerasClassifier(build_fn=model_func, nb_epoch=epochs, batch_size=batch_size, verbose=1)
+    model = KerasClassifier(model=model_func, epochs=epochs, batch_size=batch_size, verbose=1)
     model.fit(X, y)
     return model
 


### PR DESCRIPTION
The latest tensorflow release has dropped KerasClassifier and KerasRegressor scikit-learn style wrappers.  This has caused all of our gated builds to fail in our ml-wrappers repository on all PRs.  See commit in tensorflow that dropped them:
https://github.com/tensorflow/tensorflow/commit/f08737e6420fbc53f0ab2e299bee725a04499ba8

based on the issue in tensorflow:
https://github.com/tensorflow/tensorflow/issues/32532
```
It seems that the KerasRegressor and Kerasclassifier is deprecated and we are no longer maintaining/bug fixing it. Please forward this issue to https://github.com/adriangb/scikeras.
```

It seems it is recommended to move to the scikeras package instead.

Hence, this PR adds a dependency to scikeras and uses the KerasClassifier and KerasRegressor from scikeras instead for model wrapping validation tests.