### PR TITLE
fix is_sequential check for latest tensorflow 2.13

### DIFF
--- a/python/ml_wrappers/model/tensorflow_wrapper.py
+++ b/python/ml_wrappers/model/tensorflow_wrapper.py
@@ -13,18 +13,26 @@ PREDICT_CLASSES = 'predict_classes'
 def is_sequential(model):
     """Returns True if the model is a sequential model.
 
-    Note the model class name can either be
+    Note the model class name can be
+    keras.src.engine.sequential.Sequential,
     keras.engine.sequential.Sequential or
     tensorflow.python.keras.engine.sequential.Sequential
     depending on the tensorflow version.
-    The check should include both of these cases.
+    In the latest 2.13 version, the namespace changed from
+    keras.engine to keras.src.engine.
+    The check should include all of these cases.
 
     :param model: The model to check.
     :type model: tf.keras.Model
     :return: True if the model is a sequential model.
     :rtype: bool
     """
-    return str(type(model)).endswith("keras.engine.sequential.Sequential'>")
+    model_type = str(type(model))
+    # the sequential namespace changed in tensorflow 2.13
+    old_sequential_ns = "keras.engine.sequential.Sequential'>"
+    new_sequential_ns = "keras.src.engine.sequential.Sequential'>"
+    return (model_type.endswith(old_sequential_ns) or
+            model_type.endswith(new_sequential_ns))
 
 
 class WrappedTensorflowModel(object):

--- a/tests/main/test_tf_model_wrapper.py
+++ b/tests/main/test_tf_model_wrapper.py
@@ -5,10 +5,12 @@
 """Tests for WrappedTensorflowModel"""
 
 import pytest
+import tensorflow as tf
 from common_utils import (create_keras_classifier, create_keras_regressor,
                           create_scikit_keras_regressor)
 from ml_wrappers.common.constants import ModelTask
 from ml_wrappers.model import WrappedTensorflowModel
+from ml_wrappers.model.tensorflow_wrapper import is_sequential
 from train_wrapper_utils import (train_classification_model_numpy,
                                  train_classification_model_pandas,
                                  train_regression_model_numpy,
@@ -35,6 +37,10 @@ class TestTensorflowModelWrapper(object):
             create_scikit_keras_regressor, model_task=ModelTask.REGRESSION)
         train_regression_model_numpy(wrapped_init, housing)
         train_regression_model_pandas(wrapped_init, housing)
+
+    def test_validate_is_sequential(self):
+        sequential_layer = tf.keras.Sequential(layers=None, name=None)
+        assert is_sequential(sequential_layer)
 
 
 class TensorflowModelInitializer():


### PR DESCRIPTION
The Sequential layer class namespace changed in the latest tensorflow 2.13 to keras.src.engine.sequential.Sequential from the previous keras.engine.sequential.Sequential namespace.

This caused test failures in interpret-community repository for the PFI explainer:
https://github.com/interpretml/interpret-community/commit/e4e75f901a56e625811be44883492c16945d3269#diff-82a69909fb9f2e27dcff4f01ede5603b921c76d22635167fe321f73c990c8e10

The test there has been temporarily disabled for now.
This PR fixes the issue for all tensorflow versions and adds a test case.