### PR TITLE
Remove deprecated parameter `sparse` from `OneHotEncoder`

### DIFF
--- a/.github/workflows/CI-python-minimal.yml
+++ b/.github/workflows/CI-python-minimal.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         packageDirectory: ["ml_wrappers"]
         operatingSystem: [ubuntu-latest, macos-latest, windows-latest]
-        pythonVersion: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        pythonVersion: ['3.7', '3.8', '3.9', '3.10']
 
     runs-on: ${{ matrix.operatingSystem }}
 

--- a/.github/workflows/CI-python-minimal.yml
+++ b/.github/workflows/CI-python-minimal.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         packageDirectory: ["ml_wrappers"]
         operatingSystem: [ubuntu-latest, macos-latest, windows-latest]
-        pythonVersion: ['3.7', '3.8', '3.9', '3.10']
+        pythonVersion: ['3.8', '3.9', '3.10']
 
     runs-on: ${{ matrix.operatingSystem }}
 

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         packageDirectory: ["ml_wrappers"]
         operatingSystem: [ubuntu-latest, macos-latest, windows-latest]
-        pythonVersion: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        pythonVersion: ['3.7', '3.8', '3.9', '3.10']
 
     runs-on: ${{ matrix.operatingSystem }}
 

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         packageDirectory: ["ml_wrappers"]
         operatingSystem: [ubuntu-latest, macos-latest, windows-latest]
-        pythonVersion: ['3.7', '3.8', '3.9', '3.10']
+        pythonVersion: ['3.8', '3.9', '3.10']
 
     runs-on: ${{ matrix.operatingSystem }}
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,6 +1,6 @@
 # Machine Learning Wrappers SDK for Python
 
-### This package has been tested with Python 3.6, 3.7, 3.8, 3.9 and 3.10
+### This package has been tested with Python 3.8, 3.9 and 3.10
 
 The Machine Learning Wrappers SDK provides a unified wrapper for various ML frameworks - to have one uniform scikit-learn format predict and predict_proba functions.
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -26,8 +26,6 @@ CLASSIFIERS = [
     'Intended Audience :: Science/Research',
     'License :: OSI Approved :: MIT License',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.6',
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',

--- a/tests/common_utils.py
+++ b/tests/common_utils.py
@@ -591,8 +591,8 @@ def create_titanic_pipeline(X_train, y_train):
         ("embarked", Pipeline(steps=[
             ("imputer",
                 SimpleImputer(strategy='constant', fill_value='missing')),
-            ("encoder", OneHotEncoder(sparse=False))]), ["embarked"]),
-        ("sex_pclass", OneHotEncoder(sparse=False), ["sex", "pclass"])
+            ("encoder", OneHotEncoder(sparse_output=False))]), ["embarked"]),
+        ("sex_pclass", OneHotEncoder(sparse_output=False), ["sex", "pclass"])
     ])
     clf = Pipeline(steps=[('preprocessor', transformations),
                           ('classifier',


### PR DESCRIPTION
Changing this to `sparse_output` instead. More in documentation here:- https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.OneHotEncoder.html.

Also removing tests and documentation for python 3.6 and 3.7 as these versions of python are end of life.