### PR TITLE
modify automl threshold params and add gpu optimizations in object detection ml-wrappers

### DIFF
--- a/python/docs/object_detection_model_wrapping.rst
+++ b/python/docs/object_detection_model_wrapping.rst
@@ -47,7 +47,7 @@ Example:
             self._model = model
             self._number_of_classes = number_of_classes
 
-        def predict(self, x, iou_thresh: float = 0.5, score_thresh: float = 0.5):
+        def predict(self, x, iou_threshold: float = 0.5, score_threshold: float = 0.5):
             """Create a list of detection records from the image predictions."""
             detections = []
             for image in x:

--- a/tests/main/test_image_model_wrapper.py
+++ b/tests/main/test_image_model_wrapper.py
@@ -33,8 +33,7 @@ try:
     from torchvision import transforms as T
     from torchvision.models.detection.faster_rcnn import FastRCNNPredictor
 except ImportError:
-    print('Could not import torchvision, \
-    required if using a vision PyTorch model')
+    print('Could not import torch, required if using a PyTorch model')
 
 
 @pytest.mark.usefixtures('_clean_dir')
@@ -195,6 +194,10 @@ class TestImageModelWrapper(object):
         # wrap_model invocation in RAIVisionInsights
         device = _get_device("auto")
         assert device == "cpu" or device == "cuda"
+        device = _get_device("cuda:1")
+        assert device == "cuda:1"
+        device = _get_device("cpu")
+        assert device == "cpu"
 
     def _set_up_OD_model(self):
         """Returns generic model and dataset for OD testing (FastRCNN)"""


### PR DESCRIPTION
modify automl threshold params and add gpu optimizations in object detection ml-wrappers

1.) fix _get_device to be able to handle colons with device number
2.) add transforms to PytorchDRiseWrapper for AutoML support via extracting underlying model as an optimization for running AutoML models on GPU
3.) add threshold params for iou_thresh and score_thresh to predict method and also allow them to be specified on constructor
4.) rename score_thresh and iou_thresh to full name score_threshold and iou_threshold, since we have many cases where these seem to be inconsistent in the codebase - note it looks like these are not used elsewhere in our codebases so it should not affect other projects, but it is a breaking change in case other external users are calling these APIs directly
5.) add tests for the new changes