### PR TITLE
Updated return type logic for OD detections

### DIFF
--- a/python/ml_wrappers/model/image_model_wrapper.py
+++ b/python/ml_wrappers/model/image_model_wrapper.py
@@ -543,7 +543,10 @@ class WrappedObjectDetectionModel:
 
                 detections.append(image_predictions.detach().cpu().numpy()
                                   .tolist())
-        return np.array(detections)
+        try:
+          return np.array(detections)
+        except ValueError:
+          return detections
 
     def predict_proba(self, dataset, iou_threshold=0.1):
         """Predict the output probability using the wrapped model.
@@ -657,7 +660,10 @@ class WrappedMlflowAutomlObjectDetectionModel:
             detections.append(
                 image_predictions.detach().cpu().numpy().tolist())
 
-        return np.array(detections)
+        try:
+          return np.array(detections)
+        except ValueError:
+          return detections
 
     def predict_proba(self, dataset: pd.DataFrame,
                       iou_threshold=0.1) -> np.ndarray:

--- a/python/ml_wrappers/model/image_model_wrapper.py
+++ b/python/ml_wrappers/model/image_model_wrapper.py
@@ -314,7 +314,7 @@ def _get_device(device: str) -> str:
     :rtype: str
     """
     if (device in [member.value for member in Device]
-       or type(device) == int
+       or type(device) is int
        or device.isdigit()
        or device is None):
         if device == Device.AUTO.value:
@@ -525,7 +525,7 @@ class WrappedObjectDetectionModel:
         """
         detections = []
         for image in x:
-            if type(image) == Tensor:
+            if type(image) is Tensor:
                 raw_detections = self._model(
                     image.to(self._device).unsqueeze(0))
             else:
@@ -544,9 +544,9 @@ class WrappedObjectDetectionModel:
                 detections.append(image_predictions.detach().cpu().numpy()
                                   .tolist())
         try:
-          return np.array(detections)
+            return np.array(detections)
         except ValueError:
-          return detections
+            return detections
 
     def predict_proba(self, dataset, iou_threshold=0.1):
         """Predict the output probability using the wrapped model.
@@ -661,9 +661,9 @@ class WrappedMlflowAutomlObjectDetectionModel:
                 image_predictions.detach().cpu().numpy().tolist())
 
         try:
-          return np.array(detections)
+            return np.array(detections)
         except ValueError:
-          return detections
+            return detections
 
     def predict_proba(self, dataset: pd.DataFrame,
                       iou_threshold=0.1) -> np.ndarray:


### PR DESCRIPTION
The `detections` list was converted to np.array in https://github.com/microsoft/ml-wrappers/pull/139 due to the below error:

Bug 2532332 RangeIndex Error when users bring their own model with text and vision

However, conversion to np.array may not usually be technically possible as there can be variable number of detections per image which may not make the 3D list a defined-sized matrix, for example:

![image](https://github.com/microsoft/ml-wrappers/assets/37190647/6070918b-6a5b-4149-b2b1-1779f55c1b96)

Example error - https://github.com/microsoft/responsible-ai-toolbox/actions/runs/5906085087/job/16021413911?pr=2246

Hence this PR tries converting to np.array if possible to stay compatible with the return type of the rest of the wrappers, else returns the plain list with variable number of detections per image.