### PR TITLE
add default case for object detection to pass through models that have already been wrapped correctly

### DIFF
--- a/python/ml_wrappers/model/image_model_wrapper.py
+++ b/python/ml_wrappers/model/image_model_wrapper.py
@@ -295,7 +295,7 @@ def _wrap_image_model(model, examples, model_task, is_function,
             ):
                 _wrapped_model = WrappedMlflowAutomlObjectDetectionModel(
                     model, classes)
-        else:
+        elif _is_transformers_pipeline(model) or _is_callable_pipeline(model):
             _wrapped_model = WrappedObjectDetectionModel(
                 model, number_of_classes, device)
     return _wrapped_model, model_task


### PR DESCRIPTION
Currently object detection models that have been wrapped are always getting re-wrapped as a WrappedObjectDetectionModel.  However, this can cause issues for users that have already written their own custom wrapper, as is the case for one of our customers.  In the image model wrapper, we simply return the existing model if we detect that it has already been wrapped, similar to other text and tabular wrappers as well as vision wrappers for other tasks.