### PR TITLE
add optional api key auto refresh callable to EndpointWrapperModel

### DIFF
--- a/tests/main/test_endpoint_wrapper.py
+++ b/tests/main/test_endpoint_wrapper.py
@@ -5,6 +5,7 @@
 """Tests the EndpointWrapperModel class."""
 
 import json
+import urllib.request
 from unittest.mock import patch
 
 import numpy as np
@@ -16,13 +17,14 @@ from ml_wrappers.model import EndpointWrapperModel
 class MockRead():
     """Mock class for urllib.request.urlopen().read()"""
 
-    def __init__(self, json_data):
+    def __init__(self, json_data, fail_read=False):
         """Initialize the MockRead class.
 
         :param json_data: The json data to return from the read method.
         :type json_data: str
         """
         self.json_data = json_data
+        self.fail_read = fail_read
 
     def read(self):
         """Return the json data.
@@ -30,7 +32,21 @@ class MockRead():
         :return: The json data.
         :rtype: str
         """
+        if self.fail_read:
+            # reset fail_read to False so that the next call to read
+            # does not fail
+            self.fail_read = False
+            raise urllib.error.HTTPError('url', 500, 'Internal Server Error', {}, None)
         return self.json_data
+
+
+def mock_api_key_auto_refresh_method():
+    """Mock method for auto refreshing the API key.
+
+    :return: The mock API key.
+    :rtype: str
+    """
+    return 'mock_key'
 
 
 @pytest.mark.usefixtures('_clean_dir')
@@ -45,6 +61,22 @@ class TestEndpointWrapperModel(object):
             json_inference_value = json.dumps(test_dataframe.values.tolist())
             # wrap return value in mock class with read method
             mock_urlopen.return_value = MockRead(json_inference_value)
+            context = {}
+            result = endpoint_wrapper.predict(context, test_dataframe)
+            # assert result and test_dataframe.values equal
+            assert np.array_equal(result, test_dataframe.values)
+
+    def test_auto_refresh_token(self):
+        test_dataframe = pd.DataFrame(data=[[1, 2, 3]], columns=['c1,', 'c2', 'c3'])
+        endpoint_wrapper = EndpointWrapperModel.from_auto_refresh_callable(
+            mock_api_key_auto_refresh_method,
+            'http://mock.url')
+        # mock the urllib.request.urlopen function
+        with patch('urllib.request.urlopen') as mock_urlopen:
+            json_inference_value = json.dumps(test_dataframe.values.tolist())
+            # wrap return value in mock class with read method
+            mock_urlopen.return_value = MockRead(
+                json_inference_value, fail_read=True)
             context = {}
             result = endpoint_wrapper.predict(context, test_dataframe)
             # assert result and test_dataframe.values equal


### PR DESCRIPTION
Add an optional api key auto refresh callable to EndpointWrapperModel to allow the api key to be refreshed automatically.
Also adds a test.

This additional parameter/constructor was added due to errors users have encountered with the notebook:

https://github.com/Azure/azureml-examples/blob/main/sdk/python/responsible-ai/text/responsibleaidashboard-text-classification-blbooksgenre.ipynb

Specifically, after a day the api key expires, and users start to see errors like:
```
Jwt is expired
Please check this guide to understand why this error code might have been returned 
https://docs.microsoft.com/en-us/azure/machine-learning/how-to-troubleshoot-online-endpoints#http-status-codes

Failed to convert result to numpy array, json_data:
Traceback (most recent call last):
  File "/azureml-envs/responsibleai-text/lib/python3.8/site-packages/ml_wrappers/model/endpoint_wrapper.py", line 137, in _make_request
    result = np.array(json.loads(json_data))
UnboundLocalError: local variable 'json_data' referenced before assignment

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/azureml-envs/responsibleai-text/lib/python3.8/site-packages/responsibleai_text/managers/error_analysis_manager.py", line 134, in _raise_user_error_on_prediction_failure
    return func(*args, **kwargs)
  File "/azureml-envs/responsibleai-text/lib/python3.8/site-packages/ml_wrappers/model/endpoint_wrapper.py", line 191, in predict
    result = self._call_webservice(model_input)
  File "/azureml-envs/responsibleai-text/lib/python3.8/site-packages/ml_wrappers/model/endpoint_wrapper.py", line 172, in _call_webservice
    batch_result = self._make_request(data[i:i + batch_size])
  File "/azureml-envs/responsibleai-text/lib/python3.8/site-packages/ml_wrappers/model/endpoint_wrapper.py", line 140, in _make_request
    print(json_data)
UnboundLocalError: local variable 'json_data' referenced before assignment
```

Note the actual callable will be implemented in another package since we don't want to pollute this repository with platform/cloud specific logic (eg adding MLClient from AzureML here), both to keep the code separated and also because we don't have the test setup to validate the code against an AzureML workspace/services.