### PR TITLE
Fix for empty predictions

### DIFF
--- a/tests/main/test_image_model_wrapper.py
+++ b/tests/main/test_image_model_wrapper.py
@@ -241,16 +241,22 @@ class TestImageModelWrapper(object):
 
     @pytest.mark.skipif(sys.version_info.minor <= 6,
                         reason='Older versions of pytorch not supported')
-    @pytest.mark.parametrize("boxes, scores, labels, iou_threshold, expected_boxes, expected_scores, expected_labels", [
-        (torch.empty((0, 4)), torch.tensor([]), torch.tensor([]), 0.5, torch.empty((0, 4)), torch.tensor([]), torch.tensor([])),
-        (torch.tensor([[0, 0, 1, 1], [0, 0, 1, 1], [0, 0, 1, 1]]), torch.tensor([0.9, 0.8, 0.7]), torch.tensor([1, 2, 3]), 0.5, torch.tensor([[0, 0, 1, 1], [0, 0, 1, 1], [0, 0, 1, 1]]), torch.tensor([0.9, 0.8, 0.7]), torch.tensor([1, 2, 3])),
-        (torch.tensor([[0, 0, 1, 1], [0.5, 0.5, 1.5, 1.5], [1, 1, 2, 2]]), torch.tensor([0.9, 0.8, 0.7]), torch.tensor([1, 2, 3]), 0.5, torch.tensor([[0, 0, 1, 1], [1, 1, 2, 2]]), torch.tensor([0.9, 0.7]), torch.tensor([1, 3])),
+    @pytest.mark.parametrize("boxes, scores, labels, iou_threshold, expected_boxes, expected_scores,\
+                             expected_labels", [
+        (torch.empty((0, 4)), torch.tensor([]), torch.tensor([]), 0.5,
+         torch.empty((0, 4)), torch.tensor([]), torch.tensor([])),
+        (torch.tensor([[0, 0, 1, 1], [0, 0, 1, 1], [0, 0, 1, 1]]), torch.tensor([0.9, 0.8, 0.7]),
+         torch.tensor([1, 2, 3]), 0.5, torch.tensor([[0, 0, 1, 1], [0, 0, 1, 1], [0, 0, 1, 1]]),
+         torch.tensor([0.9, 0.8, 0.7]), torch.tensor([1, 2, 3])),
+        (torch.tensor([[0, 0, 1, 1], [0.5, 0.5, 1.5, 1.5], [1, 1, 2, 2]]), torch.tensor([0.9, 0.8, 0.7]),
+         torch.tensor([1, 2, 3]), 0.5, torch.tensor([[0, 0, 1, 1], [1, 1, 2, 2]]), torch.tensor([0.9, 0.7]),
+         torch.tensor([1, 3])),
     ])
-    def test_apply_nms(self, boxes, scores, labels, iou_threshold, expected_boxes, expected_scores, expected_labels):
+    def test_apply_nms(boxes, scores, labels, iou_threshold, expected_boxes, expected_scores, expected_labels):
         # Create the input dictionary
         orig_prediction = {
-            'boxes': boxes,
-            'scores': scores,
+            'boxes': boxes.float(),
+            'scores': scores.float(),
             'labels': labels
         }
 
@@ -258,6 +264,7 @@ class TestImageModelWrapper(object):
         nms_prediction = _apply_nms(orig_prediction, iou_threshold)
 
         # Check that the output is as expected
+        assert nms_prediction['boxes'].shape == expected_boxes.shape
         assert torch.all(torch.eq(nms_prediction['boxes'], expected_boxes))
         assert torch.all(torch.eq(nms_prediction['scores'], expected_scores))
         assert torch.all(torch.eq(nms_prediction['labels'], expected_labels))

--- a/tests/main/test_image_model_wrapper.py
+++ b/tests/main/test_image_model_wrapper.py
@@ -240,9 +240,9 @@ class TestImageModelWrapper(object):
                 wrapped_model = WrappedObjectDetectionModel(model, 1, 'cuda')
 
     @pytest.mark.skipif(sys.version_info.minor <= 6,
-                        reason='Older versions of pytorch not supported')
-    @pytest.mark.parametrize("boxes, scores, labels, iou_threshold, expected_boxes, expected_scores,\
-                             expected_labels", [
+                    reason='Older versions of pytorch not supported')
+    @pytest.mark.parametrize(("boxes", "scores", "labels", "iou_threshold", "expected_boxes", "expected_scores",
+                         "expected_labels"), [
         (torch.empty((0, 4)), torch.tensor([]), torch.tensor([]), 0.5,
          torch.empty((0, 4)), torch.tensor([]), torch.tensor([])),
         (torch.tensor([[0, 0, 1, 1], [0, 0, 1, 1], [0, 0, 1, 1]]), torch.tensor([0.9, 0.8, 0.7]),

--- a/tests/main/test_image_model_wrapper.py
+++ b/tests/main/test_image_model_wrapper.py
@@ -22,6 +22,7 @@ from ml_wrappers import wrap_model
 from ml_wrappers.common.constants import ModelTask
 from ml_wrappers.model.image_model_wrapper import (PytorchDRiseWrapper,
                                                    WrappedObjectDetectionModel,
+                                                   _apply_nms,
                                                    _get_device)
 from wrapper_validator import (validate_wrapped_classification_model,
                                validate_wrapped_multilabel_model,
@@ -238,6 +239,29 @@ class TestImageModelWrapper(object):
             with pytest.raises(AssertionError,
                                match="Torch not compiled with CUDA enabled"):
                 wrapped_model = WrappedObjectDetectionModel(model, 1, 'cuda')
+
+    @pytest.mark.skipif(sys.version_info.minor <= 6,
+                        reason='Older versions of pytorch not supported')
+    @pytest.mark.parametrize("boxes, scores, labels, iou_threshold, expected_boxes, expected_scores, expected_labels", [
+        (torch.empty((0, 4)), torch.tensor([]), torch.tensor([]), 0.5, torch.empty((0, 4)), torch.tensor([]), torch.tensor([])),
+        (torch.tensor([[0, 0, 1, 1], [0, 0, 1, 1], [0, 0, 1, 1]]), torch.tensor([0.9, 0.8, 0.7]), torch.tensor([1, 2, 3]), 0.5, torch.tensor([[0, 0, 1, 1], [0, 0, 1, 1], [0, 0, 1, 1]]), torch.tensor([0.9, 0.8, 0.7]), torch.tensor([1, 2, 3])),
+        (torch.tensor([[0, 0, 1, 1], [0.5, 0.5, 1.5, 1.5], [1, 1, 2, 2]]), torch.tensor([0.9, 0.8, 0.7]), torch.tensor([1, 2, 3]), 0.5, torch.tensor([[0, 0, 1, 1], [1, 1, 2, 2]]), torch.tensor([0.9, 0.7]), torch.tensor([1, 3])),
+    ])
+    def test_apply_nms(boxes, scores, labels, iou_threshold, expected_boxes, expected_scores, expected_labels):
+        # Create the input dictionary
+        orig_prediction = {
+            'boxes': boxes,
+            'scores': scores,
+            'labels': labels
+        }
+
+        # Call the function being tested
+        nms_prediction = _apply_nms(orig_prediction, iou_threshold)
+
+        # Check that the output is as expected
+        assert torch.all(torch.eq(nms_prediction['boxes'], expected_boxes))
+        assert torch.all(torch.eq(nms_prediction['scores'], expected_scores))
+        assert torch.all(torch.eq(nms_prediction['labels'], expected_labels))
 
     def test_get_device(self):
         # test default invocation of _get_device as it would be during the

--- a/tests/main/test_image_model_wrapper.py
+++ b/tests/main/test_image_model_wrapper.py
@@ -242,7 +242,7 @@ class TestImageModelWrapper(object):
     @pytest.mark.skipif(sys.version_info.minor <= 6,
                     reason='Older versions of pytorch not supported')
     @pytest.mark.parametrize(("boxes", "scores", "labels", "iou_threshold", "expected_boxes", "expected_scores",
-                         "expected_labels"), [
+                              "expected_labels"), [
         (torch.empty((0, 4)), torch.tensor([]), torch.tensor([]), 0.5,
          torch.empty((0, 4)), torch.tensor([]), torch.tensor([])),
         (torch.tensor([[0, 0, 1, 1], [0, 0, 1, 1], [0, 0, 1, 1]]), torch.tensor([0.9, 0.8, 0.7]),
@@ -252,7 +252,7 @@ class TestImageModelWrapper(object):
          torch.tensor([1, 2, 3]), 0.5, torch.tensor([[0, 0, 1, 1], [1, 1, 2, 2]]), torch.tensor([0.9, 0.7]),
          torch.tensor([1, 3])),
     ])
-    def test_apply_nms(boxes, scores, labels, iou_threshold, expected_boxes, expected_scores, expected_labels):
+    def test_apply_nms(self, boxes, scores, labels, iou_threshold, expected_boxes, expected_scores, expected_labels):
         # Create the input dictionary
         orig_prediction = {
             'boxes': boxes.float(),

--- a/tests/main/test_image_model_wrapper.py
+++ b/tests/main/test_image_model_wrapper.py
@@ -240,7 +240,7 @@ class TestImageModelWrapper(object):
                 wrapped_model = WrappedObjectDetectionModel(model, 1, 'cuda')
 
     @pytest.mark.skipif(sys.version_info.minor <= 6,
-                    reason='Older versions of pytorch not supported')
+                        reason='Older versions of pytorch not supported')
     @pytest.mark.parametrize(("boxes", "scores", "labels", "iou_threshold", "expected_boxes", "expected_scores",
                               "expected_labels"), [
         (torch.empty((0, 4)), torch.tensor([]), torch.tensor([]), 0.5,

--- a/tests/main/test_image_model_wrapper.py
+++ b/tests/main/test_image_model_wrapper.py
@@ -22,8 +22,7 @@ from ml_wrappers import wrap_model
 from ml_wrappers.common.constants import ModelTask
 from ml_wrappers.model.image_model_wrapper import (PytorchDRiseWrapper,
                                                    WrappedObjectDetectionModel,
-                                                   _apply_nms,
-                                                   _get_device)
+                                                   _apply_nms, _get_device)
 from wrapper_validator import (validate_wrapped_classification_model,
                                validate_wrapped_multilabel_model,
                                validate_wrapped_object_detection_custom_model,
@@ -247,7 +246,7 @@ class TestImageModelWrapper(object):
         (torch.tensor([[0, 0, 1, 1], [0, 0, 1, 1], [0, 0, 1, 1]]), torch.tensor([0.9, 0.8, 0.7]), torch.tensor([1, 2, 3]), 0.5, torch.tensor([[0, 0, 1, 1], [0, 0, 1, 1], [0, 0, 1, 1]]), torch.tensor([0.9, 0.8, 0.7]), torch.tensor([1, 2, 3])),
         (torch.tensor([[0, 0, 1, 1], [0.5, 0.5, 1.5, 1.5], [1, 1, 2, 2]]), torch.tensor([0.9, 0.8, 0.7]), torch.tensor([1, 2, 3]), 0.5, torch.tensor([[0, 0, 1, 1], [1, 1, 2, 2]]), torch.tensor([0.9, 0.7]), torch.tensor([1, 3])),
     ])
-    def test_apply_nms(boxes, scores, labels, iou_threshold, expected_boxes, expected_scores, expected_labels):
+    def test_apply_nms(self, boxes, scores, labels, iou_threshold, expected_boxes, expected_scores, expected_labels):
         # Create the input dictionary
         orig_prediction = {
             'boxes': boxes,


### PR DESCRIPTION
Fix for below issue:

<class 'RuntimeError'> File "/azureml-envs/responsibleai-vision/lib/python3.8/site-packages/azureml/rai/utils/telemetry/loggerfactory.py", line 153 in wrapper return func(*args, **kwargs) File "./rai_vision_insights.py", line 456 in main rai_vi = RAIVisionInsights( File "/azureml-envs/responsibleai-vision/lib/python3.8/site-packages/responsibleai_vision/rai_vision_insights/rai_vision_insights.py", line 254 in __init__ self._initialize_managers() File "/azureml-envs/responsibleai-vision/lib/python3.8/site-packages/responsibleai_vision/rai_vision_insights/rai_vision_insights.py", line 271 in _initialize_managers self._error_analysis_manager = ErrorAnalysisManager( File "/azureml-envs/responsibleai-vision/lib/python3.8/site-packages/responsibleai_vision/managers/error_analysis_manager.py", line 198 in __init__ index_predictor = ErrorAnalysisManager._create_index_predictor( File "/azureml-envs/responsibleai-vision/lib/python3.8/site-packages/responsibleai_vision/managers/error_analysis_manager.py", line 243 in _create_index_predictor index_predictor = WrappedIndexPredictorModel( File "/azureml-envs/responsibleai-vision/lib/python3.8/site-packages/responsibleai_vision/managers/error_analysis_manager.py", line 103 in __init__ self.predictions = self.model.predict(test) File "/azureml-envs/responsibleai-vision/lib/python3.8/site-packages/ml_wrappers/model/image_model_wrapper.py", line 646 in predict raw_detections = _apply_nms(raw_detections, iou_threshold) File "/azureml-envs/responsibleai-vision/lib/python3.8/site-packages/ml_wrappers/model/image_model_wrapper.py", line 103 in _apply_nms keep = torchvision.ops.nms(orig_prediction[BOXES], File "/azureml-envs/responsibleai-vision/lib/python3.8/site-packages/torchvision/ops/boxes.py", line 40 in nms return torch.ops.torchvision.nms(boxes, scores, iou_threshold)
RuntimeError: boxes should be a 2d tensor, got 1D

Repro'd with:

Case when the predictions are empty (i.e. no predictions by the OD model)

> torchvision.ops.nms(torch.tensor([]), torch.tensor([]), iou_threshold=0.5)
Traceback (most recent call last):
File "<stdin>", line 1, in <module>
File "C:\Users\agemawat\Anaconda3\envs\rai\lib\site-packages\torchvision\ops\boxes.py", line 41, in nms
return torch.ops.torchvision.nms(boxes, scores, iou_threshold)
File "C:\Users\agemawat\Anaconda3\envs\rai\lib\site-packages\torch_ops.py", line 502, in call
return self._op(*args, **kwargs or {})
RuntimeError: boxes should be a 2d tensor, got 1D