### PR TITLE
fix openai wrapper compatibility with older version of openai less than 1.0.0

### DIFF
--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -15,6 +15,16 @@ jobs:
         packageDirectory: ["ml_wrappers"]
         operatingSystem: [ubuntu-latest, macos-latest, windows-latest]
         pythonVersion: ['3.8', '3.9', '3.10']
+        openaiVersion: ['0.28.1', 'openai-latest']
+        exclude:
+          - openaiVersion: '0.28.1'
+            pythonVersion: '3.9'
+          - openaiVersion: '0.28.1'
+            pythonVersion: '3.10'
+          - openaiVersion: '0.28.1'
+            operatingSystem: 'macos-latest'
+          - openaiVersion: '0.28.1'
+            operatingSystem: 'windows-latest'
 
     runs-on: ${{ matrix.operatingSystem }}
 
@@ -61,6 +71,11 @@ jobs:
       shell: bash -l {0}
       run: |
         pip install -r requirements-test.txt
+    - if: ${{ matrix.openaiVersion != 'openai-latest' }}
+      name: Install openai version ${{ matrix.openaiVersion }}
+      shell: bash -l {0}
+      run: |
+        pip install openai==${{ matrix.openaiVersion }}
     - name: Test with pytest
       shell: bash -l {0}
       run: |

--- a/python/ml_wrappers/model/openai_wrapper.py
+++ b/python/ml_wrappers/model/openai_wrapper.py
@@ -168,6 +168,7 @@ class OpenaiWrapperModel(object):
                 data = data.tolist()
             else:
                 data = data.values.tolist()
+        client = None
         if hasattr(openai, OPENAI):
             if self.api_type == AZURE:
                 client = AzureOpenAI(api_key=self.api_key, azure_endpoint=self.api_base,

--- a/tests/main/test_openai_wrapper.py
+++ b/tests/main/test_openai_wrapper.py
@@ -11,9 +11,14 @@ import openai
 import pandas as pd
 import pytest
 from ml_wrappers.model import OpenaiWrapperModel
-from openai.types.chat.chat_completion import (ChatCompletion,
-                                               ChatCompletionMessage, Choice,
-                                               CompletionUsage)
+
+try:
+    from openai.types.chat.chat_completion import (ChatCompletion,
+                                                   ChatCompletionMessage,
+                                                   Choice, CompletionUsage)
+except ImportError:
+    # Ignore the error, only used by new openai version
+    pass
 
 CHOICES = 'choices'
 MESSAGE = 'message'


### PR DESCRIPTION
Customer encountered exception when using openai<1.0.0 with OpenaiWrapperModel from ml-wrappers:

![image](https://github.com/microsoft/ml-wrappers/assets/24683184/22edf2f6-57a6-4e10-8443-d09799c2c264)

Fixing error and adding test case with old version of openai in test matrix to validate.