### PR TITLE
Fixed the check for openai version before API call

### DIFF
--- a/python/ml_wrappers/model/openai_wrapper.py
+++ b/python/ml_wrappers/model/openai_wrapper.py
@@ -83,7 +83,7 @@ class ChatCompletion(object):
         :return: The response.
         :rtype: dict
         """
-        if hasattr(openai, CHAT_COMPLETION):
+        if self.client is None:                             # openai<1.0.0
             return openai.ChatCompletion.create(
                 engine=self.engine,
                 messages=self.messages,
@@ -93,7 +93,7 @@ class ChatCompletion(object):
                 frequency_penalty=self.frequency_penalty,
                 presence_penalty=self.presence_penalty,
                 stop=self.stop)
-        else:
+        else:                                               # openai>=1.0.0
             return self.client.chat.completions.create(
                 model=self.engine,
                 messages=self.messages,


### PR DESCRIPTION
The current implementation checks if the `ChatCompletion` attribute exists in the `openai` package and calls it if it does. 

The newer version of the `openai` package has this attribute but it is programmed to show an error message saying the user is trying to access a symbol that is no longer supported. So, the `hasattr` check passes but the call to `ChatCompletion` then fails.

This check is now replaced with `self.client is None` which is true for `openai<1.0.0` and false for `openai>=1.0.0`, so the correct method is called for all versions.