### PR TITLE
Add ability to pass sys prompt and history in OpenAI API call

### DIFF
--- a/python/ml_wrappers/model/openai_wrapper.py
+++ b/python/ml_wrappers/model/openai_wrapper.py
@@ -149,7 +149,7 @@ class OpenaiWrapperModel(object):
         self.presence_penalty = presence_penalty
         self.stop = stop
 
-    def _call_webservice(self, data):
+    def _call_webservice(self, data, history=None, sys_prompt=None):
         """Common code to call the webservice.
 
         :param data: The data to send to the webservice.
@@ -181,8 +181,12 @@ class OpenaiWrapperModel(object):
             openai.api_type = self.api_type
             openai.api_version = self.api_version
         answers = []
-        for doc in data:
+        for i, doc in enumerate(data):
             messages = []
+            if sys_prompt is not None:
+                messages.append({'role': 'system', CONTENT: sys_prompt.iloc[i]})
+            if history is not None:
+                messages.extend(history.iloc[i])
             messages.append({'role': 'user', CONTENT: doc})
             fetcher = ChatCompletion(messages, self.engine, self.temperature,
                                      self.max_tokens, self.top_p,
@@ -217,7 +221,9 @@ class OpenaiWrapperModel(object):
         if model_input is None:
             model_input = context
         questions = model_input['questions']
+        history = model_input.get('history')
+        sys_prompt = model_input.get('sys_prompt')
         if isinstance(questions, str):
             questions = [questions]
-        result = self._call_webservice(questions)
+        result = self._call_webservice(questions, history, sys_prompt)
         return result


### PR DESCRIPTION
If the input DataFrame to `model.predict` has `"sys_prompt"` and/or `"history"` columns, they are used to provide the system prompt and history of the chat to the API call respectively, along with the prompt itself in the `"questions"` column.

The `"sys_prompt"` should be a string, while the `"history"` should be a list of dictionaries containing the messages. For example:

```python
data = {
    'sys_prompt' : ['You are a helpful assistant', 'Your responses should always be in all CAPS'],
    'history' : [
        [
            {'role': 'user', 'content': 'What is the capital of France?'},
            {'role': 'assistant', 'content': 'The capital of France is Paris.'}
        ],
        [] # empty history for second question
    ],
    'questions' : ['What is its population?', 'Who is the president of the United States?']
}
df = pd.DataFrame(data)
openai_model.predict(df)

>>> array(['As of the latest reports, the population of Paris is approximately 2.16 million people as of 2021. However, the population significantly increases to around 10.8 million when considering the broader metropolitan area.',
       'AS OF MY LAST UPDATE, THE PRESIDENT OF THE UNITED STATES IS JOE BIDEN.'],
      dtype='<U217')
```