### PR TITLE
Kartikch/openai sys prompt

### DIFF
--- a/python/ml_wrappers/model/openai_wrapper.py
+++ b/python/ml_wrappers/model/openai_wrapper.py
@@ -152,11 +152,15 @@ class OpenaiWrapperModel(object):
         self.presence_penalty = presence_penalty
         self.stop = stop
 
-    def _call_webservice(self, data):
+    def _call_webservice(self, data, history=None, sys_prompt=None):
         """Common code to call the webservice.
 
         :param data: The data to send to the webservice.
         :type data: pandas.DataFrame or list
+        :param history: The history.
+        :type history: pandas.Series
+        :param sys_prompt: The system prompt.
+        :type sys_prompt: pandas.Series
         :return: The result.
         :rtype: numpy.ndarray
         """
@@ -184,8 +188,12 @@ class OpenaiWrapperModel(object):
             openai.api_type = self.api_type
             openai.api_version = self.api_version
         answers = []
-        for doc in data:
+        for i, doc in enumerate(data):
             messages = []
+            if sys_prompt is not None:
+                messages.append({'role': 'system', CONTENT: sys_prompt.iloc[i]})
+            if history is not None:
+                messages.extend(history.iloc[i])
             messages.append({'role': 'user', CONTENT: doc})
             fetcher = ChatCompletion(messages, self.engine, self.temperature,
                                      self.max_tokens, self.top_p,
@@ -220,7 +228,9 @@ class OpenaiWrapperModel(object):
         if model_input is None:
             model_input = context
         questions = model_input['questions']
+        history = model_input.get('history')
+        sys_prompt = model_input.get('sys_prompt')
         if isinstance(questions, str):
             questions = [questions]
-        result = self._call_webservice(questions)
+        result = self._call_webservice(questions, history, sys_prompt)
         return result

--- a/python/ml_wrappers/model/openai_wrapper.py
+++ b/python/ml_wrappers/model/openai_wrapper.py
@@ -6,6 +6,7 @@
 
 import numpy as np
 import pandas as pd
+
 try:
     import openai
     openai_installed = True

--- a/tests/main/test_openai_wrapper.py
+++ b/tests/main/test_openai_wrapper.py
@@ -27,45 +27,7 @@ CONTENT = 'content'
 
 @pytest.mark.usefixtures('_clean_dir')
 class TestOpenaiWrapperModel(object):
-    @pytest.mark.skipif(sys.version_info.minor <= 6,
-                        reason='Openai not supported for older versions')
-    def test_predict_call(self):
-        # test creating the OpenaiWrapperModel and
-        # calling the predict function
-        api_type = 'azure'
-        api_base = 'https://mock.openai.azure.com/'
-        api_version = '2023-03-15-preview'
-        api_key = 'mock'
-        context = ''
-        questions = 'How to convert 10^9/l to liter?'
-        is_openai_1_0 = False
-        if not hasattr(openai, 'OpenAI'):
-            mock_function = 'openai.ChatCompletion.create'
-        else:
-            mock_function = 'openai.resources.chat.completions.Completions.create'
-            is_openai_1_0 = True
-        answer = (' It seems there is some confusion with the units being'
-                  ' used in your question. The symbol `10^9/l` is often'
-                  ' used to represent a concentration of 10^9 molecules'
-                  ' or particles per liter of a solution. However, it is'
-                  ' not a unit of volume and cannot be directly converted'
-                  ' to liters. If you are trying to convert a concentration'
-                  ' from one unit to another, such as from micrograms per'
-                  ' liter (µg/L) to milligrams per liter (mg/L), you can'
-                  ' use the appropriate conversion factor. For example,'
-                  ' 1 µg/L is equal to 0.001 mg/L. If you need help'
-                  ' with a specific conversion, please provide more'
-                  ' details and I will do my best to assist you.')
-        test_data = pd.DataFrame(data=[[context, questions, answer]],
-                                 columns=['context', 'questions', 'answer'])
-        expected_content = ('To convert from 10^9 per liter to '
-                            'liters, you need to find the '
-                            'reciprocal of the given value.'
-                            '\n\nReciprocal of 10^9 per '
-                            'liter = 1 / (10^9 per liter)'
-                            '\n\nSo, the value in liters '
-                            'is 1 / 10^9 liters, or '
-                            '10^(-9) liters.')
+    def create_mock_result(self, expected_content, is_openai_1_0: bool):
         expected_model = 'gpt-4-32k'
         expected_id = 'chatcmpl-XYZ'
         expected_object = 'chat.completion'
@@ -113,6 +75,48 @@ class TestOpenaiWrapperModel(object):
                     'total_tokens': expected_total_tokens
                 }
             }
+        return mock_result
+
+    @pytest.mark.skipif(sys.version_info.minor <= 6,
+                        reason='Openai not supported for older versions')
+    def test_predict_call(self):
+        # test creating the OpenaiWrapperModel and
+        # calling the predict function
+        api_type = 'azure'
+        api_base = 'https://mock.openai.azure.com/'
+        api_version = '2023-03-15-preview'
+        api_key = 'mock'
+        context = ''
+        questions = 'How to convert 10^9/l to liter?'
+        is_openai_1_0 = False
+        if not hasattr(openai, 'OpenAI'):
+            mock_function = 'openai.ChatCompletion.create'
+        else:
+            mock_function = 'openai.resources.chat.completions.Completions.create'
+            is_openai_1_0 = True
+        answer = (' It seems there is some confusion with the units being'
+                  ' used in your question. The symbol `10^9/l` is often'
+                  ' used to represent a concentration of 10^9 molecules'
+                  ' or particles per liter of a solution. However, it is'
+                  ' not a unit of volume and cannot be directly converted'
+                  ' to liters. If you are trying to convert a concentration'
+                  ' from one unit to another, such as from micrograms per'
+                  ' liter (µg/L) to milligrams per liter (mg/L), you can'
+                  ' use the appropriate conversion factor. For example,'
+                  ' 1 µg/L is equal to 0.001 mg/L. If you need help'
+                  ' with a specific conversion, please provide more'
+                  ' details and I will do my best to assist you.')
+        test_data = pd.DataFrame(data=[[context, questions, answer]],
+                                 columns=['context', 'questions', 'answer'])
+        expected_content = ('To convert from 10^9 per liter to '
+                            'liters, you need to find the '
+                            'reciprocal of the given value.'
+                            '\n\nReciprocal of 10^9 per '
+                            'liter = 1 / (10^9 per liter)'
+                            '\n\nSo, the value in liters '
+                            'is 1 / 10^9 liters, or '
+                            '10^(-9) liters.')
+        mock_result = self.create_mock_result(expected_content, is_openai_1_0)
         openai_model = OpenaiWrapperModel(
             api_type, api_base, api_version, api_key)
         # mock the openai create function
@@ -127,3 +131,972 @@ class TestOpenaiWrapperModel(object):
                 expected_result = mock_result[CHOICES][0][MESSAGE][CONTENT]
             assert len(result) == 1
             assert result[0] == expected_result
+
+    @pytest.mark.skipif(sys.version_info.minor <= 6,
+                        reason='Openai not supported for older versions')
+    def test_predict_call_with_sys_prompt(self):
+        # test creating the OpenaiWrapperModel and
+        # calling the predict function
+        api_type = 'azure'
+        api_base = 'https://mock.openai.azure.com/'
+        api_version = '2023-03-15-preview'
+        api_key = 'mock'
+        context = ''
+        questions = 'How to convert 10^9/l to liter?'
+        sys_prompt = 'You are a helpful assistant.'
+        is_openai_1_0 = False
+        if not hasattr(openai, 'OpenAI'):
+            mock_function = 'openai.ChatCompletion.create'
+        else:
+            mock_function = 'openai.resources.chat.completions.Completions.create'
+            is_openai_1_0 = True
+        answer = (' It seems there is some confusion with the units being'
+                  ' used in your question. The symbol `10^9/l` is often'
+                  ' used to represent a concentration of 10^9 molecules'
+                  ' or particles per liter of a solution. However, it is'
+                  ' not a unit of volume and cannot be directly converted'
+                  ' to liters. If you are trying to convert a concentration'
+                  ' from one unit to another, such as from micrograms per'
+                  ' liter (µg/L) to milligrams per liter (mg/L), you can'
+                  ' use the appropriate conversion factor. For example,'
+                  ' 1 µg/L is equal to 0.001 mg/L. If you need help'
+                  ' with a specific conversion, please provide more'
+                  ' details and I will do my best to assist you.')
+        test_data = pd.DataFrame(data=[[context, questions, answer, sys_prompt]],
+                                 columns=['context', 'questions', 'answer', 'sys_prompt'])
+        expected_content = ('To convert from 10^9 per liter to '
+                            'liters, you need to find the '
+                            'reciprocal of the given value.'
+                            '\n\nReciprocal of 10^9 per '
+                            'liter = 1 / (10^9 per liter)'
+                            '\n\nSo, the value in liters '
+                            'is 1 / 10^9 liters, or '
+                            '10^(-9) liters.')
+        expected_model = 'gpt-4-32k'
+        mock_result = self.create_mock_result(expected_content, is_openai_1_0)
+        openai_model = OpenaiWrapperModel(
+            api_type, api_base, api_version, api_key)
+        # mock the openai create function
+        with patch(mock_function) as mock_create:
+            # wrap return value in mock class with read method
+            mock_create.return_value = mock_result
+            context = {}
+            result = openai_model.predict(context, test_data)
+            if is_openai_1_0:
+                mock_create.assert_called_with(
+                    model=expected_model,
+                    messages=[
+                        {'role': 'system', 'content': sys_prompt},
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+            else:
+                mock_create.assert_called_with(
+                    engine=expected_model,
+                    messages=[
+                        {'role': 'system', 'content': sys_prompt},
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+            if is_openai_1_0:
+                expected_result = mock_result.choices[0].message.content
+            else:
+                expected_result = mock_result[CHOICES][0][MESSAGE][CONTENT]
+            assert len(result) == 1
+            assert result[0] == expected_result
+
+    @pytest.mark.skipif(sys.version_info.minor <= 6,
+                        reason='Openai not supported for older versions')
+    def test_predict_call_with_history(self):
+        # test creating the OpenaiWrapperModel and
+        # calling the predict function
+        api_type = 'azure'
+        api_base = 'https://mock.openai.azure.com/'
+        api_version = '2023-03-15-preview'
+        api_key = 'mock'
+        context = ''
+        questions = 'How to convert 10^9/l to liter?'
+        history = [
+            {'role': 'user', 'content': 'How are you?'},
+            {'role': 'assistant', 'content': 'I am good. How can I help you?'}
+        ]
+        is_openai_1_0 = False
+        if not hasattr(openai, 'OpenAI'):
+            mock_function = 'openai.ChatCompletion.create'
+        else:
+            mock_function = 'openai.resources.chat.completions.Completions.create'
+            is_openai_1_0 = True
+        answer = (' It seems there is some confusion with the units being'
+                  ' used in your question. The symbol `10^9/l` is often'
+                  ' used to represent a concentration of 10^9 molecules'
+                  ' or particles per liter of a solution. However, it is'
+                  ' not a unit of volume and cannot be directly converted'
+                  ' to liters. If you are trying to convert a concentration'
+                  ' from one unit to another, such as from micrograms per'
+                  ' liter (µg/L) to milligrams per liter (mg/L), you can'
+                  ' use the appropriate conversion factor. For example,'
+                  ' 1 µg/L is equal to 0.001 mg/L. If you need help'
+                  ' with a specific conversion, please provide more'
+                  ' details and I will do my best to assist you.')
+        test_data = pd.DataFrame(data=[[context, questions, answer, history]],
+                                 columns=['context', 'questions', 'answer', 'history'])
+        expected_content = ('To convert from 10^9 per liter to '
+                            'liters, you need to find the '
+                            'reciprocal of the given value.'
+                            '\n\nReciprocal of 10^9 per '
+                            'liter = 1 / (10^9 per liter)'
+                            '\n\nSo, the value in liters '
+                            'is 1 / 10^9 liters, or '
+                            '10^(-9) liters.')
+        expected_model = 'gpt-4-32k'
+        mock_result = self.create_mock_result(expected_content, is_openai_1_0)
+        openai_model = OpenaiWrapperModel(
+            api_type, api_base, api_version, api_key)
+        # mock the openai create function
+        with patch(mock_function) as mock_create:
+            # wrap return value in mock class with read method
+            mock_create.return_value = mock_result
+            context = {}
+            result = openai_model.predict(context, test_data)
+            if is_openai_1_0:
+                mock_create.assert_called_with(
+                    model=expected_model,
+                    messages=[
+                        *history,
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+            else:
+                mock_create.assert_called_with(
+                    engine=expected_model,
+                    messages=[
+                        *history,
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+            if is_openai_1_0:
+                expected_result = mock_result.choices[0].message.content
+            else:
+                expected_result = mock_result[CHOICES][0][MESSAGE][CONTENT]
+            assert len(result) == 1
+            assert result[0] == expected_result
+
+    @pytest.mark.skipif(sys.version_info.minor <= 6,
+                        reason='Openai not supported for older versions')
+    def test_predict_call_with_sys_prompt_and_history(self):
+        # test creating the OpenaiWrapperModel and
+        # calling the predict function
+        api_type = 'azure'
+        api_base = 'https://mock.openai.azure.com/'
+        api_version = '2023-03-15-preview'
+        api_key = 'mock'
+        context = ''
+        questions = 'How to convert 10^9/l to liter?'
+        sys_prompt = 'You are a helpful assistant.'
+        history = [
+            {'role': 'user', 'content': 'How are you?'},
+            {'role': 'assistant', 'content': 'I am good. How can I help you?'}
+        ]
+        is_openai_1_0 = False
+        if not hasattr(openai, 'OpenAI'):
+            mock_function = 'openai.ChatCompletion.create'
+        else:
+            mock_function = 'openai.resources.chat.completions.Completions.create'
+            is_openai_1_0 = True
+        answer = (' It seems there is some confusion with the units being'
+                  ' used in your question. The symbol `10^9/l` is often'
+                  ' used to represent a concentration of 10^9 molecules'
+                  ' or particles per liter of a solution. However, it is'
+                  ' not a unit of volume and cannot be directly converted'
+                  ' to liters. If you are trying to convert a concentration'
+                  ' from one unit to another, such as from micrograms per'
+                  ' liter (µg/L) to milligrams per liter (mg/L), you can'
+                  ' use the appropriate conversion factor. For example,'
+                  ' 1 µg/L is equal to 0.001 mg/L. If you need help'
+                  ' with a specific conversion, please provide more'
+                  ' details and I will do my best to assist you.')
+        test_data = pd.DataFrame(data=[[context, questions, answer, history, sys_prompt]],
+                                 columns=['context', 'questions', 'answer', 'history', 'sys_prompt'])
+        expected_content = ('To convert from 10^9 per liter to '
+                            'liters, you need to find the '
+                            'reciprocal of the given value.'
+                            '\n\nReciprocal of 10^9 per '
+                            'liter = 1 / (10^9 per liter)'
+                            '\n\nSo, the value in liters '
+                            'is 1 / 10^9 liters, or '
+                            '10^(-9) liters.')
+        expected_model = 'gpt-4-32k'
+        mock_result = self.create_mock_result(expected_content, is_openai_1_0)
+        openai_model = OpenaiWrapperModel(
+            api_type, api_base, api_version, api_key)
+        # mock the openai create function
+        with patch(mock_function) as mock_create:
+            # wrap return value in mock class with read method
+            mock_create.return_value = mock_result
+            context = {}
+            result = openai_model.predict(context, test_data)
+            if is_openai_1_0:
+                mock_create.assert_called_with(
+                    model=expected_model,
+                    messages=[
+                        {'role': 'system', 'content': sys_prompt},
+                        *history,
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+            else:
+                mock_create.assert_called_with(
+                    engine=expected_model,
+                    messages=[
+                        {'role': 'system', 'content': sys_prompt},
+                        *history,
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+            if is_openai_1_0:
+                expected_result = mock_result.choices[0].message.content
+            else:
+                expected_result = mock_result[CHOICES][0][MESSAGE][CONTENT]
+            assert len(result) == 1
+            assert result[0] == expected_result
+
+    @pytest.mark.skipif(sys.version_info.minor <= 6,
+                        reason='Openai not supported for older versions')
+    def test_predict_call_df(self):
+        # test creating the OpenaiWrapperModel and
+        # calling the predict function
+        api_type = 'azure'
+        api_base = 'https://mock.openai.azure.com/'
+        api_version = '2023-03-15-preview'
+        api_key = 'mock'
+        context = ''
+        questions = 'How to convert 10^9/l to liter?'
+        sys_prompt = 'You are a helpful assistant.'
+        history = [
+            {'role': 'user', 'content': 'How are you?'},
+            {'role': 'assistant', 'content': 'I am good. How can I help you?'}
+        ]
+        is_openai_1_0 = False
+        if not hasattr(openai, 'OpenAI'):
+            mock_function = 'openai.ChatCompletion.create'
+        else:
+            mock_function = 'openai.resources.chat.completions.Completions.create'
+            is_openai_1_0 = True
+
+        expected_model = 'gpt-4-32k'
+        mock_result = self.create_mock_result('mock', is_openai_1_0)
+
+        openai_model = OpenaiWrapperModel(
+            api_type, api_base, api_version, api_key)
+
+        # mock the openai create function
+        with patch(mock_function) as mock_create:
+            # wrap return value in mock class with read method
+            mock_create.return_value = mock_result
+            context = {}
+
+            # Only prompt
+            test_data = pd.DataFrame(data=[[context, questions]],
+                                     columns=['context', 'questions'])
+            openai_model.predict(context, test_data)
+            if is_openai_1_0:
+                mock_create.assert_called_with(
+                    model=expected_model,
+                    messages=[
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+            else:
+                mock_create.assert_called_with(
+                    engine=expected_model,
+                    messages=[
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+
+            # Prompt and sys_prompt
+            test_data = pd.DataFrame(data=[[context, questions, sys_prompt]],
+                                     columns=['context', 'questions', 'sys_prompt'])
+            openai_model.predict(context, test_data)
+            if is_openai_1_0:
+                mock_create.assert_called_with(
+                    model=expected_model,
+                    messages=[
+                        {'role': 'system', 'content': sys_prompt},
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+            else:
+                mock_create.assert_called_with(
+                    engine=expected_model,
+                    messages=[
+                        {'role': 'system', 'content': sys_prompt},
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+
+            # Prompt and history
+            test_data = pd.DataFrame(data=[[context, questions, history]],
+                                     columns=['context', 'questions', 'history'])
+            openai_model.predict(context, test_data)
+            if is_openai_1_0:
+                mock_create.assert_called_with(
+                    model=expected_model,
+                    messages=[
+                        *history,
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+            else:
+                mock_create.assert_called_with(
+                    engine=expected_model,
+                    messages=[
+                        *history,
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+
+            # Prompt, history, and sys_prompt
+            test_data = pd.DataFrame(data=[[context, questions, history, sys_prompt]],
+                                     columns=['context', 'questions', 'history', 'sys_prompt'])
+            openai_model.predict(context, test_data)
+            if is_openai_1_0:
+                mock_create.assert_called_with(
+                    model=expected_model,
+                    messages=[
+                        {'role': 'system', 'content': sys_prompt},
+                        *history,
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+            else:
+                mock_create.assert_called_with(
+                    engine=expected_model,
+                    messages=[
+                        {'role': 'system', 'content': sys_prompt},
+                        *history,
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+
+    @pytest.mark.skipif(sys.version_info.minor <= 6,
+                        reason='Openai not supported for older versions')
+    def test_predict_call_dict(self):
+        # test creating the OpenaiWrapperModel and
+        # calling the predict function
+        api_type = 'azure'
+        api_base = 'https://mock.openai.azure.com/'
+        api_version = '2023-03-15-preview'
+        api_key = 'mock'
+        context = ''
+        questions = 'How to convert 10^9/l to liter?'
+        sys_prompt = 'You are a helpful assistant.'
+        history = [
+            {'role': 'user', 'content': 'How are you?'},
+            {'role': 'assistant', 'content': 'I am good. How can I help you?'}
+        ]
+        is_openai_1_0 = False
+        if not hasattr(openai, 'OpenAI'):
+            mock_function = 'openai.ChatCompletion.create'
+        else:
+            mock_function = 'openai.resources.chat.completions.Completions.create'
+            is_openai_1_0 = True
+
+        expected_model = 'gpt-4-32k'
+        mock_result = self.create_mock_result('mock', is_openai_1_0)
+
+        openai_model = OpenaiWrapperModel(
+            api_type, api_base, api_version, api_key)
+
+        # mock the openai create function
+        with patch(mock_function) as mock_create:
+            # wrap return value in mock class with read method
+            mock_create.return_value = mock_result
+            context = {}
+
+            # Only prompt
+            test_data = {
+                'context': [context],
+                'questions': [questions]
+            }
+            openai_model.predict(context, test_data)
+            if is_openai_1_0:
+                mock_create.assert_called_with(
+                    model=expected_model,
+                    messages=[
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+            else:
+                mock_create.assert_called_with(
+                    engine=expected_model,
+                    messages=[
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+
+            # Prompt and sys_prompt
+            test_data = {
+                'context': [context],
+                'questions': [questions],
+                'sys_prompt': [sys_prompt]
+            }
+            openai_model.predict(context, test_data)
+            if is_openai_1_0:
+                mock_create.assert_called_with(
+                    model=expected_model,
+                    messages=[
+                        {'role': 'system', 'content': sys_prompt},
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+            else:
+                mock_create.assert_called_with(
+                    engine=expected_model,
+                    messages=[
+                        {'role': 'system', 'content': sys_prompt},
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+
+            # Prompt and history
+            test_data = {
+                'context': [context],
+                'questions': [questions],
+                'history': [history]
+            }
+            openai_model.predict(context, test_data)
+            if is_openai_1_0:
+                mock_create.assert_called_with(
+                    model=expected_model,
+                    messages=[
+                        *history,
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+            else:
+                mock_create.assert_called_with(
+                    engine=expected_model,
+                    messages=[
+                        *history,
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+
+            # Prompt, history, and sys_prompt
+            test_data = {
+                'context': [context],
+                'questions': [questions],
+                'history': [history],
+                'sys_prompt': [sys_prompt]
+            }
+            openai_model.predict(context, test_data)
+            if is_openai_1_0:
+                mock_create.assert_called_with(
+                    model=expected_model,
+                    messages=[
+                        {'role': 'system', 'content': sys_prompt},
+                        *history,
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+            else:
+                mock_create.assert_called_with(
+                    engine=expected_model,
+                    messages=[
+                        {'role': 'system', 'content': sys_prompt},
+                        *history,
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+
+    @pytest.mark.skipif(sys.version_info.minor <= 6,
+                        reason='Openai not supported for older versions')
+    def test_predict_call_dict_of_str(self):
+        # test creating the OpenaiWrapperModel and
+        # calling the predict function
+        api_type = 'azure'
+        api_base = 'https://mock.openai.azure.com/'
+        api_version = '2023-03-15-preview'
+        api_key = 'mock'
+        context = ''
+        questions = 'How to convert 10^9/l to liter?'
+        sys_prompt = 'You are a helpful assistant.'
+        history = [
+            {'role': 'user', 'content': 'How are you?'},
+            {'role': 'assistant', 'content': 'I am good. How can I help you?'}
+        ]
+        is_openai_1_0 = False
+        if not hasattr(openai, 'OpenAI'):
+            mock_function = 'openai.ChatCompletion.create'
+        else:
+            mock_function = 'openai.resources.chat.completions.Completions.create'
+            is_openai_1_0 = True
+
+        expected_model = 'gpt-4-32k'
+        mock_result = self.create_mock_result('mock', is_openai_1_0)
+
+        openai_model = OpenaiWrapperModel(
+            api_type, api_base, api_version, api_key)
+
+        # mock the openai create function
+        with patch(mock_function) as mock_create:
+            # wrap return value in mock class with read method
+            mock_create.return_value = mock_result
+            context = {}
+
+            # Only prompt
+            test_data = {
+                'context': [context],
+                'questions': [questions]
+            }
+            openai_model.predict(context, test_data)
+            if is_openai_1_0:
+                mock_create.assert_called_with(
+                    model=expected_model,
+                    messages=[
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+            else:
+                mock_create.assert_called_with(
+                    engine=expected_model,
+                    messages=[
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+
+            # Prompt and sys_prompt
+            test_data = {
+                'context': context,
+                'questions': questions,
+                'sys_prompt': sys_prompt
+            }
+            openai_model.predict(context, test_data)
+            if is_openai_1_0:
+                mock_create.assert_called_with(
+                    model=expected_model,
+                    messages=[
+                        {'role': 'system', 'content': sys_prompt},
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+            else:
+                mock_create.assert_called_with(
+                    engine=expected_model,
+                    messages=[
+                        {'role': 'system', 'content': sys_prompt},
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+
+            # Prompt and history
+            test_data = {
+                'context': context,
+                'questions': questions,
+                'history': history
+            }
+            openai_model.predict(context, test_data)
+            if is_openai_1_0:
+                mock_create.assert_called_with(
+                    model=expected_model,
+                    messages=[
+                        *history,
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+            else:
+                mock_create.assert_called_with(
+                    engine=expected_model,
+                    messages=[
+                        *history,
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+
+            # Prompt, history, and sys_prompt
+            test_data = {
+                'context': context,
+                'questions': questions,
+                'history': history,
+                'sys_prompt': sys_prompt
+            }
+            openai_model.predict(context, test_data)
+            if is_openai_1_0:
+                mock_create.assert_called_with(
+                    model=expected_model,
+                    messages=[
+                        {'role': 'system', 'content': sys_prompt},
+                        *history,
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+            else:
+                mock_create.assert_called_with(
+                    engine=expected_model,
+                    messages=[
+                        {'role': 'system', 'content': sys_prompt},
+                        *history,
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+
+    @pytest.mark.skipif(sys.version_info.minor <= 6,
+                        reason='Openai not supported for older versions')
+    def test_predict_call_str(self):
+        # test creating the OpenaiWrapperModel and
+        # calling the predict function
+        api_type = 'azure'
+        api_base = 'https://mock.openai.azure.com/'
+        api_version = '2023-03-15-preview'
+        api_key = 'mock'
+        context = ''
+        questions = 'How to convert 10^9/l to liter?'
+        is_openai_1_0 = False
+        if not hasattr(openai, 'OpenAI'):
+            mock_function = 'openai.ChatCompletion.create'
+        else:
+            mock_function = 'openai.resources.chat.completions.Completions.create'
+            is_openai_1_0 = True
+
+        expected_model = 'gpt-4-32k'
+        mock_result = self.create_mock_result('mock', is_openai_1_0)
+
+        openai_model = OpenaiWrapperModel(
+            api_type, api_base, api_version, api_key)
+
+        # mock the openai create function
+        with patch(mock_function) as mock_create:
+            # wrap return value in mock class with read method
+            mock_create.return_value = mock_result
+            context = {}
+
+            # Only prompt
+            test_data = questions
+            openai_model.predict(context, test_data)
+            if is_openai_1_0:
+                mock_create.assert_called_with(
+                    model=expected_model,
+                    messages=[
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+            else:
+                mock_create.assert_called_with(
+                    engine=expected_model,
+                    messages=[
+                        {'role': 'user', 'content': questions}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+
+    @pytest.mark.skipif(sys.version_info.minor <= 6,
+                        reason='Openai not supported for older versions')
+    def test_predict_call_list_of_str(self):
+        # test creating the OpenaiWrapperModel and
+        # calling the predict function
+        api_type = 'azure'
+        api_base = 'https://mock.openai.azure.com/'
+        api_version = '2023-03-15-preview'
+        api_key = 'mock'
+        context = ''
+        questions = ['How to convert 10^9/l to liter?']
+        is_openai_1_0 = False
+        if not hasattr(openai, 'OpenAI'):
+            mock_function = 'openai.ChatCompletion.create'
+        else:
+            mock_function = 'openai.resources.chat.completions.Completions.create'
+            is_openai_1_0 = True
+
+        expected_model = 'gpt-4-32k'
+        mock_result = self.create_mock_result('mock', is_openai_1_0)
+
+        openai_model = OpenaiWrapperModel(
+            api_type, api_base, api_version, api_key)
+
+        # mock the openai create function
+        with patch(mock_function) as mock_create:
+            # wrap return value in mock class with read method
+            mock_create.return_value = mock_result
+            context = {}
+
+            # Only prompt
+            test_data = questions
+            openai_model.predict(context, test_data)
+            if is_openai_1_0:
+                mock_create.assert_called_with(
+                    model=expected_model,
+                    messages=[
+                        {'role': 'user', 'content': questions[0]}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+            else:
+                mock_create.assert_called_with(
+                    engine=expected_model,
+                    messages=[
+                        {'role': 'user', 'content': questions[0]}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+
+    @pytest.mark.skipif(sys.version_info.minor <= 6,
+                        reason='Openai not supported for older versions')
+    def test_predict_call_series(self):
+        # test creating the OpenaiWrapperModel and
+        # calling the predict function
+        api_type = 'azure'
+        api_base = 'https://mock.openai.azure.com/'
+        api_version = '2023-03-15-preview'
+        api_key = 'mock'
+        context = ''
+        questions = pd.Series('How to convert 10^9/l to liter?')
+        is_openai_1_0 = False
+        if not hasattr(openai, 'OpenAI'):
+            mock_function = 'openai.ChatCompletion.create'
+        else:
+            mock_function = 'openai.resources.chat.completions.Completions.create'
+            is_openai_1_0 = True
+
+        expected_model = 'gpt-4-32k'
+        mock_result = self.create_mock_result('mock', is_openai_1_0)
+
+        openai_model = OpenaiWrapperModel(
+            api_type, api_base, api_version, api_key)
+
+        # mock the openai create function
+        with patch(mock_function) as mock_create:
+            # wrap return value in mock class with read method
+            mock_create.return_value = mock_result
+            context = {}
+
+            # Only prompt
+            test_data = questions
+            openai_model.predict(context, test_data)
+            if is_openai_1_0:
+                mock_create.assert_called_with(
+                    model=expected_model,
+                    messages=[
+                        {'role': 'user', 'content': questions[0]}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )
+            else:
+                mock_create.assert_called_with(
+                    engine=expected_model,
+                    messages=[
+                        {'role': 'user', 'content': questions[0]}
+                    ],
+                    temperature=openai_model.temperature,
+                    max_tokens=openai_model.max_tokens,
+                    top_p=openai_model.top_p,
+                    frequency_penalty=openai_model.frequency_penalty,
+                    presence_penalty=openai_model.presence_penalty,
+                    stop=openai_model.stop
+                )

--- a/tests/main/test_openai_wrapper.py
+++ b/tests/main/test_openai_wrapper.py
@@ -27,6 +27,28 @@ CONTENT = 'content'
 
 @pytest.mark.usefixtures('_clean_dir')
 class TestOpenaiWrapperModel(object):
+    QUESTION = 'How to convert 10^9/l to liter?'
+    ANSWER = (' It seems there is some confusion with the units being'
+              ' used in your question. The symbol `10^9/l` is often'
+              ' used to represent a concentration of 10^9 molecules'
+              ' or particles per liter of a solution. However, it is'
+              ' not a unit of volume and cannot be directly converted'
+              ' to liters. If you are trying to convert a concentration'
+              ' from one unit to another, such as from micrograms per'
+              ' liter (µg/L) to milligrams per liter (mg/L), you can'
+              ' use the appropriate conversion factor. For example,'
+              ' 1 µg/L is equal to 0.001 mg/L. If you need help'
+              ' with a specific conversion, please provide more'
+              ' details and I will do my best to assist you.')
+    EXPECTED_ANSWER = ('To convert from 10^9 per liter to '
+                       'liters, you need to find the '
+                       'reciprocal of the given value.'
+                       '\n\nReciprocal of 10^9 per '
+                       'liter = 1 / (10^9 per liter)'
+                       '\n\nSo, the value in liters '
+                       'is 1 / 10^9 liters, or '
+                       '10^(-9) liters.')
+
     def create_mock_result(self, expected_content, is_openai_1_0: bool):
         expected_model = 'gpt-4-32k'
         expected_id = 'chatcmpl-XYZ'
@@ -77,145 +99,104 @@ class TestOpenaiWrapperModel(object):
             }
         return mock_result
 
-    @pytest.mark.skipif(sys.version_info.minor <= 6,
-                        reason='Openai not supported for older versions')
-    def test_predict_call(self):
-        # test creating the OpenaiWrapperModel and
-        # calling the predict function
+    def get_model_params(self):
+        ret = {
+            'context': '',
+            'expected_model': 'gpt-4-32k'
+        }
         api_type = 'azure'
         api_base = 'https://mock.openai.azure.com/'
         api_version = '2023-03-15-preview'
         api_key = 'mock'
-        context = ''
-        questions = 'How to convert 10^9/l to liter?'
+        ret['openai_model'] = OpenaiWrapperModel(
+            api_type, api_base, api_version, api_key)
         is_openai_1_0 = False
         if not hasattr(openai, 'OpenAI'):
             mock_function = 'openai.ChatCompletion.create'
         else:
             mock_function = 'openai.resources.chat.completions.Completions.create'
             is_openai_1_0 = True
-        answer = (' It seems there is some confusion with the units being'
-                  ' used in your question. The symbol `10^9/l` is often'
-                  ' used to represent a concentration of 10^9 molecules'
-                  ' or particles per liter of a solution. However, it is'
-                  ' not a unit of volume and cannot be directly converted'
-                  ' to liters. If you are trying to convert a concentration'
-                  ' from one unit to another, such as from micrograms per'
-                  ' liter (µg/L) to milligrams per liter (mg/L), you can'
-                  ' use the appropriate conversion factor. For example,'
-                  ' 1 µg/L is equal to 0.001 mg/L. If you need help'
-                  ' with a specific conversion, please provide more'
-                  ' details and I will do my best to assist you.')
-        test_data = pd.DataFrame(data=[[context, questions, answer]],
-                                 columns=['context', 'questions', 'answer'])
-        expected_content = ('To convert from 10^9 per liter to '
-                            'liters, you need to find the '
-                            'reciprocal of the given value.'
-                            '\n\nReciprocal of 10^9 per '
-                            'liter = 1 / (10^9 per liter)'
-                            '\n\nSo, the value in liters '
-                            'is 1 / 10^9 liters, or '
-                            '10^(-9) liters.')
-        mock_result = self.create_mock_result(expected_content, is_openai_1_0)
-        openai_model = OpenaiWrapperModel(
-            api_type, api_base, api_version, api_key)
+        ret['is_openai_1_0'] = is_openai_1_0
+        ret['mock_function'] = mock_function
+        return ret
+
+    def assert_result(self, params, mock_result, test_data):
         # mock the openai create function
-        with patch(mock_function) as mock_create:
+        with patch(params['mock_function']) as mock_create:
             # wrap return value in mock class with read method
             mock_create.return_value = mock_result
             context = {}
-            result = openai_model.predict(context, test_data)
-            if is_openai_1_0:
+            result = params['openai_model'].predict(context, test_data)
+            if params['is_openai_1_0']:
                 expected_result = mock_result.choices[0].message.content
             else:
                 expected_result = mock_result[CHOICES][0][MESSAGE][CONTENT]
             assert len(result) == 1
             assert result[0] == expected_result
 
-    @pytest.mark.skipif(sys.version_info.minor <= 6,
-                        reason='Openai not supported for older versions')
-    def test_predict_call_with_sys_prompt(self):
-        # test creating the OpenaiWrapperModel and
-        # calling the predict function
-        api_type = 'azure'
-        api_base = 'https://mock.openai.azure.com/'
-        api_version = '2023-03-15-preview'
-        api_key = 'mock'
-        context = ''
-        questions = 'How to convert 10^9/l to liter?'
-        sys_prompt = 'You are a helpful assistant.'
-        is_openai_1_0 = False
-        if not hasattr(openai, 'OpenAI'):
-            mock_function = 'openai.ChatCompletion.create'
-        else:
-            mock_function = 'openai.resources.chat.completions.Completions.create'
-            is_openai_1_0 = True
-        answer = (' It seems there is some confusion with the units being'
-                  ' used in your question. The symbol `10^9/l` is often'
-                  ' used to represent a concentration of 10^9 molecules'
-                  ' or particles per liter of a solution. However, it is'
-                  ' not a unit of volume and cannot be directly converted'
-                  ' to liters. If you are trying to convert a concentration'
-                  ' from one unit to another, such as from micrograms per'
-                  ' liter (µg/L) to milligrams per liter (mg/L), you can'
-                  ' use the appropriate conversion factor. For example,'
-                  ' 1 µg/L is equal to 0.001 mg/L. If you need help'
-                  ' with a specific conversion, please provide more'
-                  ' details and I will do my best to assist you.')
-        test_data = pd.DataFrame(data=[[context, questions, answer, sys_prompt]],
-                                 columns=['context', 'questions', 'answer', 'sys_prompt'])
-        expected_content = ('To convert from 10^9 per liter to '
-                            'liters, you need to find the '
-                            'reciprocal of the given value.'
-                            '\n\nReciprocal of 10^9 per '
-                            'liter = 1 / (10^9 per liter)'
-                            '\n\nSo, the value in liters '
-                            'is 1 / 10^9 liters, or '
-                            '10^(-9) liters.')
-        expected_model = 'gpt-4-32k'
-        mock_result = self.create_mock_result(expected_content, is_openai_1_0)
-        openai_model = OpenaiWrapperModel(
-            api_type, api_base, api_version, api_key)
+    def assert_called_with(self, params,
+            mock_result,test_data, **kwargs):
         # mock the openai create function
-        with patch(mock_function) as mock_create:
+        with patch(params['mock_function']) as mock_create:
             # wrap return value in mock class with read method
             mock_create.return_value = mock_result
             context = {}
-            result = openai_model.predict(context, test_data)
-            if is_openai_1_0:
+            params['openai_model'].predict(context, test_data)
+            messages = []
+            if 'sys_prompt' in kwargs:
+                messages.append({'role': 'system', 'content': kwargs['sys_prompt']})
+            if 'history' in kwargs:
+                messages.extend(kwargs['history'])
+            messages.append({'role': 'user', 'content': kwargs['questions']})
+            if params['is_openai_1_0']:
                 mock_create.assert_called_with(
-                    model=expected_model,
-                    messages=[
-                        {'role': 'system', 'content': sys_prompt},
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
+                    model=params['expected_model'],
+                    messages=messages,
+                    temperature=params['openai_model'].temperature,
+                    max_tokens=params['openai_model'].max_tokens,
+                    top_p=params['openai_model'].top_p,
+                    frequency_penalty=params['openai_model'].frequency_penalty,
+                    presence_penalty=params['openai_model'].presence_penalty,
+                    stop=params['openai_model'].stop
                 )
             else:
                 mock_create.assert_called_with(
-                    engine=expected_model,
-                    messages=[
-                        {'role': 'system', 'content': sys_prompt},
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
+                    engine=params['expected_model'],
+                    messages=messages,
+                    temperature=params['openai_model'].temperature,
+                    max_tokens=params['openai_model'].max_tokens,
+                    top_p=params['openai_model'].top_p,
+                    frequency_penalty=params['openai_model'].frequency_penalty,
+                    presence_penalty=params['openai_model'].presence_penalty,
+                    stop=params['openai_model'].stop
                 )
-            if is_openai_1_0:
-                expected_result = mock_result.choices[0].message.content
-            else:
-                expected_result = mock_result[CHOICES][0][MESSAGE][CONTENT]
-            assert len(result) == 1
-            assert result[0] == expected_result
+
+    @pytest.mark.skipif(sys.version_info.minor <= 6,
+                        reason='Openai not supported for older versions')
+    def test_predict_call(self):
+        params = self.get_model_params()
+        questions = self.QUESTION
+        answer = self.ANSWER
+        test_data = pd.DataFrame(data=[[params['context'], questions, answer]],
+                                 columns=['context', 'questions', 'answer'])
+        expected_content = self.EXPECTED_ANSWER
+        mock_result = self.create_mock_result(expected_content, params['is_openai_1_0'])
+
+        self.assert_result(params, mock_result, test_data)
+
+    @pytest.mark.skipif(sys.version_info.minor <= 6,
+                        reason='Openai not supported for older versions')
+    def test_predict_call_with_sys_prompt(self):
+        params = self.get_model_params()
+        questions = self.QUESTION
+        sys_prompt = 'You are a helpful assistant.'
+        answer = self.ANSWER
+        test_data = pd.DataFrame(data=[[params['context'], questions, answer, sys_prompt]],
+                                 columns=['context', 'questions', 'answer', 'sys_prompt'])
+        expected_content = self.EXPECTED_ANSWER
+        mock_result = self.create_mock_result(expected_content, params['is_openai_1_0'])
+        self.assert_result(params, mock_result, test_data)
+        self.assert_called_with(params, mock_result, test_data, sys_prompt=sys_prompt, questions=questions)
 
     @pytest.mark.skipif(sys.version_info.minor <= 6,
                         reason='Openai not supported for older versions')

--- a/tests/main/test_openai_wrapper.py
+++ b/tests/main/test_openai_wrapper.py
@@ -48,6 +48,11 @@ class TestOpenaiWrapperModel(object):
                        '\n\nSo, the value in liters '
                        'is 1 / 10^9 liters, or '
                        '10^(-9) liters.')
+    SYS_PROMPT = 'You are a helpful assistant.'
+    HISTORY = [
+        {'role': 'user', 'content': 'How are you?'},
+        {'role': 'assistant', 'content': 'I am good. How can I help you?'}
+    ]
 
     def create_mock_result(self, expected_content, is_openai_1_0: bool):
         expected_model = 'gpt-4-32k'
@@ -134,8 +139,7 @@ class TestOpenaiWrapperModel(object):
             assert len(result) == 1
             assert result[0] == expected_result
 
-    def assert_called_with(self, params,
-            mock_result,test_data, **kwargs):
+    def assert_called_with(self, params, mock_result, test_data, **kwargs):
         # mock the openai create function
         with patch(params['mock_function']) as mock_create:
             # wrap return value in mock class with read method
@@ -189,895 +193,212 @@ class TestOpenaiWrapperModel(object):
     def test_predict_call_with_sys_prompt(self):
         params = self.get_model_params()
         questions = self.QUESTION
-        sys_prompt = 'You are a helpful assistant.'
+        sys_prompt = self.SYS_PROMPT
         answer = self.ANSWER
         test_data = pd.DataFrame(data=[[params['context'], questions, answer, sys_prompt]],
                                  columns=['context', 'questions', 'answer', 'sys_prompt'])
         expected_content = self.EXPECTED_ANSWER
         mock_result = self.create_mock_result(expected_content, params['is_openai_1_0'])
         self.assert_result(params, mock_result, test_data)
-        self.assert_called_with(params, mock_result, test_data, sys_prompt=sys_prompt, questions=questions)
+        self.assert_called_with(params, mock_result, test_data,
+                                sys_prompt=sys_prompt, questions=questions)
 
     @pytest.mark.skipif(sys.version_info.minor <= 6,
                         reason='Openai not supported for older versions')
     def test_predict_call_with_history(self):
-        # test creating the OpenaiWrapperModel and
-        # calling the predict function
-        api_type = 'azure'
-        api_base = 'https://mock.openai.azure.com/'
-        api_version = '2023-03-15-preview'
-        api_key = 'mock'
-        context = ''
-        questions = 'How to convert 10^9/l to liter?'
-        history = [
-            {'role': 'user', 'content': 'How are you?'},
-            {'role': 'assistant', 'content': 'I am good. How can I help you?'}
-        ]
-        is_openai_1_0 = False
-        if not hasattr(openai, 'OpenAI'):
-            mock_function = 'openai.ChatCompletion.create'
-        else:
-            mock_function = 'openai.resources.chat.completions.Completions.create'
-            is_openai_1_0 = True
-        answer = (' It seems there is some confusion with the units being'
-                  ' used in your question. The symbol `10^9/l` is often'
-                  ' used to represent a concentration of 10^9 molecules'
-                  ' or particles per liter of a solution. However, it is'
-                  ' not a unit of volume and cannot be directly converted'
-                  ' to liters. If you are trying to convert a concentration'
-                  ' from one unit to another, such as from micrograms per'
-                  ' liter (µg/L) to milligrams per liter (mg/L), you can'
-                  ' use the appropriate conversion factor. For example,'
-                  ' 1 µg/L is equal to 0.001 mg/L. If you need help'
-                  ' with a specific conversion, please provide more'
-                  ' details and I will do my best to assist you.')
-        test_data = pd.DataFrame(data=[[context, questions, answer, history]],
+        params = self.get_model_params()
+        questions = self.QUESTION
+        history = self.HISTORY
+        answer = self.ANSWER
+        test_data = pd.DataFrame(data=[[params['context'], questions, answer, history]],
                                  columns=['context', 'questions', 'answer', 'history'])
-        expected_content = ('To convert from 10^9 per liter to '
-                            'liters, you need to find the '
-                            'reciprocal of the given value.'
-                            '\n\nReciprocal of 10^9 per '
-                            'liter = 1 / (10^9 per liter)'
-                            '\n\nSo, the value in liters '
-                            'is 1 / 10^9 liters, or '
-                            '10^(-9) liters.')
-        expected_model = 'gpt-4-32k'
-        mock_result = self.create_mock_result(expected_content, is_openai_1_0)
-        openai_model = OpenaiWrapperModel(
-            api_type, api_base, api_version, api_key)
-        # mock the openai create function
-        with patch(mock_function) as mock_create:
-            # wrap return value in mock class with read method
-            mock_create.return_value = mock_result
-            context = {}
-            result = openai_model.predict(context, test_data)
-            if is_openai_1_0:
-                mock_create.assert_called_with(
-                    model=expected_model,
-                    messages=[
-                        *history,
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-            else:
-                mock_create.assert_called_with(
-                    engine=expected_model,
-                    messages=[
-                        *history,
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-            if is_openai_1_0:
-                expected_result = mock_result.choices[0].message.content
-            else:
-                expected_result = mock_result[CHOICES][0][MESSAGE][CONTENT]
-            assert len(result) == 1
-            assert result[0] == expected_result
+        expected_content = self.EXPECTED_ANSWER
+        mock_result = self.create_mock_result(expected_content, params['is_openai_1_0'])
+        self.assert_result(params, mock_result, test_data)
+        self.assert_called_with(params, mock_result, test_data,
+                                history=history, questions=questions)
 
     @pytest.mark.skipif(sys.version_info.minor <= 6,
                         reason='Openai not supported for older versions')
     def test_predict_call_with_sys_prompt_and_history(self):
-        # test creating the OpenaiWrapperModel and
-        # calling the predict function
-        api_type = 'azure'
-        api_base = 'https://mock.openai.azure.com/'
-        api_version = '2023-03-15-preview'
-        api_key = 'mock'
-        context = ''
-        questions = 'How to convert 10^9/l to liter?'
-        sys_prompt = 'You are a helpful assistant.'
-        history = [
-            {'role': 'user', 'content': 'How are you?'},
-            {'role': 'assistant', 'content': 'I am good. How can I help you?'}
-        ]
-        is_openai_1_0 = False
-        if not hasattr(openai, 'OpenAI'):
-            mock_function = 'openai.ChatCompletion.create'
-        else:
-            mock_function = 'openai.resources.chat.completions.Completions.create'
-            is_openai_1_0 = True
-        answer = (' It seems there is some confusion with the units being'
-                  ' used in your question. The symbol `10^9/l` is often'
-                  ' used to represent a concentration of 10^9 molecules'
-                  ' or particles per liter of a solution. However, it is'
-                  ' not a unit of volume and cannot be directly converted'
-                  ' to liters. If you are trying to convert a concentration'
-                  ' from one unit to another, such as from micrograms per'
-                  ' liter (µg/L) to milligrams per liter (mg/L), you can'
-                  ' use the appropriate conversion factor. For example,'
-                  ' 1 µg/L is equal to 0.001 mg/L. If you need help'
-                  ' with a specific conversion, please provide more'
-                  ' details and I will do my best to assist you.')
-        test_data = pd.DataFrame(data=[[context, questions, answer, history, sys_prompt]],
-                                 columns=['context', 'questions', 'answer', 'history', 'sys_prompt'])
-        expected_content = ('To convert from 10^9 per liter to '
-                            'liters, you need to find the '
-                            'reciprocal of the given value.'
-                            '\n\nReciprocal of 10^9 per '
-                            'liter = 1 / (10^9 per liter)'
-                            '\n\nSo, the value in liters '
-                            'is 1 / 10^9 liters, or '
-                            '10^(-9) liters.')
-        expected_model = 'gpt-4-32k'
-        mock_result = self.create_mock_result(expected_content, is_openai_1_0)
-        openai_model = OpenaiWrapperModel(
-            api_type, api_base, api_version, api_key)
-        # mock the openai create function
-        with patch(mock_function) as mock_create:
-            # wrap return value in mock class with read method
-            mock_create.return_value = mock_result
-            context = {}
-            result = openai_model.predict(context, test_data)
-            if is_openai_1_0:
-                mock_create.assert_called_with(
-                    model=expected_model,
-                    messages=[
-                        {'role': 'system', 'content': sys_prompt},
-                        *history,
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-            else:
-                mock_create.assert_called_with(
-                    engine=expected_model,
-                    messages=[
-                        {'role': 'system', 'content': sys_prompt},
-                        *history,
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-            if is_openai_1_0:
-                expected_result = mock_result.choices[0].message.content
-            else:
-                expected_result = mock_result[CHOICES][0][MESSAGE][CONTENT]
-            assert len(result) == 1
-            assert result[0] == expected_result
+        params = self.get_model_params()
+        questions = self.QUESTION
+        sys_prompt = self.SYS_PROMPT
+        history = self.HISTORY
+        answer = self.ANSWER
+        test_data = pd.DataFrame(data=[[params['context'], questions, answer, sys_prompt, history]],
+                                 columns=['context', 'questions', 'answer', 'sys_prompt', 'history'])
+        expected_content = self.EXPECTED_ANSWER
+        mock_result = self.create_mock_result(expected_content, params['is_openai_1_0'])
+        self.assert_result(params, mock_result, test_data)
+        self.assert_called_with(params, mock_result, test_data,
+                                sys_prompt=sys_prompt, history=history,
+                                questions=questions)
 
     @pytest.mark.skipif(sys.version_info.minor <= 6,
                         reason='Openai not supported for older versions')
     def test_predict_call_df(self):
-        # test creating the OpenaiWrapperModel and
-        # calling the predict function
-        api_type = 'azure'
-        api_base = 'https://mock.openai.azure.com/'
-        api_version = '2023-03-15-preview'
-        api_key = 'mock'
-        context = ''
-        questions = 'How to convert 10^9/l to liter?'
-        sys_prompt = 'You are a helpful assistant.'
-        history = [
-            {'role': 'user', 'content': 'How are you?'},
-            {'role': 'assistant', 'content': 'I am good. How can I help you?'}
-        ]
-        is_openai_1_0 = False
-        if not hasattr(openai, 'OpenAI'):
-            mock_function = 'openai.ChatCompletion.create'
-        else:
-            mock_function = 'openai.resources.chat.completions.Completions.create'
-            is_openai_1_0 = True
+        params = self.get_model_params()
+        questions = self.QUESTION
+        sys_prompt = self.SYS_PROMPT
+        history = self.HISTORY
+        expected_content = self.EXPECTED_ANSWER
+        mock_result = self.create_mock_result(expected_content, params['is_openai_1_0'])
 
-        expected_model = 'gpt-4-32k'
-        mock_result = self.create_mock_result('mock', is_openai_1_0)
+        # Only prompt
+        test_data = pd.DataFrame(data=[[params['context'], questions]],
+                                 columns=['context', 'questions'])
+        self.assert_called_with(params, mock_result, test_data,
+                                questions=questions)
 
-        openai_model = OpenaiWrapperModel(
-            api_type, api_base, api_version, api_key)
+        # Prompt and sys_prompt
+        test_data = pd.DataFrame(data=[[params['context'], questions, sys_prompt]],
+                                 columns=['context', 'questions', 'sys_prompt'])
+        self.assert_called_with(params, mock_result, test_data,
+                                sys_prompt=sys_prompt, questions=questions)
 
-        # mock the openai create function
-        with patch(mock_function) as mock_create:
-            # wrap return value in mock class with read method
-            mock_create.return_value = mock_result
-            context = {}
+        # Prompt and history
+        test_data = pd.DataFrame(data=[[params['context'], questions, history]],
+                                 columns=['context', 'questions', 'history'])
+        self.assert_called_with(params, mock_result, test_data,
+                                history=history, questions=questions)
 
-            # Only prompt
-            test_data = pd.DataFrame(data=[[context, questions]],
-                                     columns=['context', 'questions'])
-            openai_model.predict(context, test_data)
-            if is_openai_1_0:
-                mock_create.assert_called_with(
-                    model=expected_model,
-                    messages=[
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-            else:
-                mock_create.assert_called_with(
-                    engine=expected_model,
-                    messages=[
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-
-            # Prompt and sys_prompt
-            test_data = pd.DataFrame(data=[[context, questions, sys_prompt]],
-                                     columns=['context', 'questions', 'sys_prompt'])
-            openai_model.predict(context, test_data)
-            if is_openai_1_0:
-                mock_create.assert_called_with(
-                    model=expected_model,
-                    messages=[
-                        {'role': 'system', 'content': sys_prompt},
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-            else:
-                mock_create.assert_called_with(
-                    engine=expected_model,
-                    messages=[
-                        {'role': 'system', 'content': sys_prompt},
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-
-            # Prompt and history
-            test_data = pd.DataFrame(data=[[context, questions, history]],
-                                     columns=['context', 'questions', 'history'])
-            openai_model.predict(context, test_data)
-            if is_openai_1_0:
-                mock_create.assert_called_with(
-                    model=expected_model,
-                    messages=[
-                        *history,
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-            else:
-                mock_create.assert_called_with(
-                    engine=expected_model,
-                    messages=[
-                        *history,
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-
-            # Prompt, history, and sys_prompt
-            test_data = pd.DataFrame(data=[[context, questions, history, sys_prompt]],
-                                     columns=['context', 'questions', 'history', 'sys_prompt'])
-            openai_model.predict(context, test_data)
-            if is_openai_1_0:
-                mock_create.assert_called_with(
-                    model=expected_model,
-                    messages=[
-                        {'role': 'system', 'content': sys_prompt},
-                        *history,
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-            else:
-                mock_create.assert_called_with(
-                    engine=expected_model,
-                    messages=[
-                        {'role': 'system', 'content': sys_prompt},
-                        *history,
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
+        # Prompt, history, and sys_prompt
+        test_data = pd.DataFrame(data=[[params['context'], questions, history, sys_prompt]],
+                                 columns=['context', 'questions', 'history', 'sys_prompt'])
+        self.assert_called_with(params, mock_result, test_data,
+                                sys_prompt=sys_prompt, history=history,
+                                questions=questions)
 
     @pytest.mark.skipif(sys.version_info.minor <= 6,
                         reason='Openai not supported for older versions')
     def test_predict_call_dict(self):
-        # test creating the OpenaiWrapperModel and
-        # calling the predict function
-        api_type = 'azure'
-        api_base = 'https://mock.openai.azure.com/'
-        api_version = '2023-03-15-preview'
-        api_key = 'mock'
-        context = ''
-        questions = 'How to convert 10^9/l to liter?'
-        sys_prompt = 'You are a helpful assistant.'
-        history = [
-            {'role': 'user', 'content': 'How are you?'},
-            {'role': 'assistant', 'content': 'I am good. How can I help you?'}
-        ]
-        is_openai_1_0 = False
-        if not hasattr(openai, 'OpenAI'):
-            mock_function = 'openai.ChatCompletion.create'
-        else:
-            mock_function = 'openai.resources.chat.completions.Completions.create'
-            is_openai_1_0 = True
+        params = self.get_model_params()
+        questions = self.QUESTION
+        sys_prompt = self.SYS_PROMPT
+        history = self.HISTORY
+        expected_content = self.EXPECTED_ANSWER
+        mock_result = self.create_mock_result(expected_content, params['is_openai_1_0'])
 
-        expected_model = 'gpt-4-32k'
-        mock_result = self.create_mock_result('mock', is_openai_1_0)
+        # Only prompt
+        test_data = {
+            'context': [params['context']],
+            'questions': [questions]
+        }
+        self.assert_called_with(params, mock_result, test_data,
+                                questions=questions)
 
-        openai_model = OpenaiWrapperModel(
-            api_type, api_base, api_version, api_key)
+        # Prompt and sys_prompt
+        test_data = {
+            'context': [params['context']],
+            'questions': [questions],
+            'sys_prompt': [sys_prompt]
+        }
+        self.assert_called_with(params, mock_result, test_data,
+                                sys_prompt=sys_prompt, questions=questions)
 
-        # mock the openai create function
-        with patch(mock_function) as mock_create:
-            # wrap return value in mock class with read method
-            mock_create.return_value = mock_result
-            context = {}
+        # Prompt and history
+        test_data = {
+            'context': [params['context']],
+            'questions': [questions],
+            'history': [history]
+        }
+        self.assert_called_with(params, mock_result, test_data,
+                                history=history, questions=questions)
 
-            # Only prompt
-            test_data = {
-                'context': [context],
-                'questions': [questions]
-            }
-            openai_model.predict(context, test_data)
-            if is_openai_1_0:
-                mock_create.assert_called_with(
-                    model=expected_model,
-                    messages=[
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-            else:
-                mock_create.assert_called_with(
-                    engine=expected_model,
-                    messages=[
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-
-            # Prompt and sys_prompt
-            test_data = {
-                'context': [context],
-                'questions': [questions],
-                'sys_prompt': [sys_prompt]
-            }
-            openai_model.predict(context, test_data)
-            if is_openai_1_0:
-                mock_create.assert_called_with(
-                    model=expected_model,
-                    messages=[
-                        {'role': 'system', 'content': sys_prompt},
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-            else:
-                mock_create.assert_called_with(
-                    engine=expected_model,
-                    messages=[
-                        {'role': 'system', 'content': sys_prompt},
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-
-            # Prompt and history
-            test_data = {
-                'context': [context],
-                'questions': [questions],
-                'history': [history]
-            }
-            openai_model.predict(context, test_data)
-            if is_openai_1_0:
-                mock_create.assert_called_with(
-                    model=expected_model,
-                    messages=[
-                        *history,
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-            else:
-                mock_create.assert_called_with(
-                    engine=expected_model,
-                    messages=[
-                        *history,
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-
-            # Prompt, history, and sys_prompt
-            test_data = {
-                'context': [context],
-                'questions': [questions],
-                'history': [history],
-                'sys_prompt': [sys_prompt]
-            }
-            openai_model.predict(context, test_data)
-            if is_openai_1_0:
-                mock_create.assert_called_with(
-                    model=expected_model,
-                    messages=[
-                        {'role': 'system', 'content': sys_prompt},
-                        *history,
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-            else:
-                mock_create.assert_called_with(
-                    engine=expected_model,
-                    messages=[
-                        {'role': 'system', 'content': sys_prompt},
-                        *history,
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
+        # Prompt, history, and sys_prompt
+        test_data = {
+            'context': [params['context']],
+            'questions': [questions],
+            'history': [history],
+            'sys_prompt': [sys_prompt]
+        }
+        self.assert_called_with(params, mock_result, test_data,
+                                sys_prompt=sys_prompt, history=history,
+                                questions=questions)
 
     @pytest.mark.skipif(sys.version_info.minor <= 6,
                         reason='Openai not supported for older versions')
     def test_predict_call_dict_of_str(self):
-        # test creating the OpenaiWrapperModel and
-        # calling the predict function
-        api_type = 'azure'
-        api_base = 'https://mock.openai.azure.com/'
-        api_version = '2023-03-15-preview'
-        api_key = 'mock'
-        context = ''
-        questions = 'How to convert 10^9/l to liter?'
-        sys_prompt = 'You are a helpful assistant.'
-        history = [
-            {'role': 'user', 'content': 'How are you?'},
-            {'role': 'assistant', 'content': 'I am good. How can I help you?'}
-        ]
-        is_openai_1_0 = False
-        if not hasattr(openai, 'OpenAI'):
-            mock_function = 'openai.ChatCompletion.create'
-        else:
-            mock_function = 'openai.resources.chat.completions.Completions.create'
-            is_openai_1_0 = True
+        params = self.get_model_params()
+        questions = self.QUESTION
+        sys_prompt = self.SYS_PROMPT
+        history = self.HISTORY
+        expected_content = self.EXPECTED_ANSWER
+        mock_result = self.create_mock_result(expected_content, params['is_openai_1_0'])
 
-        expected_model = 'gpt-4-32k'
-        mock_result = self.create_mock_result('mock', is_openai_1_0)
+        # Only prompt
+        test_data = {
+            'context': params['context'],
+            'questions': questions
+        }
+        self.assert_called_with(params, mock_result, test_data,
+                                questions=questions)
 
-        openai_model = OpenaiWrapperModel(
-            api_type, api_base, api_version, api_key)
+        # Prompt and sys_prompt
+        test_data = {
+            'context': params['context'],
+            'questions': questions,
+            'sys_prompt': sys_prompt
+        }
+        self.assert_called_with(params, mock_result, test_data,
+                                sys_prompt=sys_prompt, questions=questions)
 
-        # mock the openai create function
-        with patch(mock_function) as mock_create:
-            # wrap return value in mock class with read method
-            mock_create.return_value = mock_result
-            context = {}
+        # Prompt and history
+        test_data = {
+            'context': params['context'],
+            'questions': questions,
+            'history': history
+        }
+        self.assert_called_with(params, mock_result, test_data,
+                                history=history, questions=questions)
 
-            # Only prompt
-            test_data = {
-                'context': [context],
-                'questions': [questions]
-            }
-            openai_model.predict(context, test_data)
-            if is_openai_1_0:
-                mock_create.assert_called_with(
-                    model=expected_model,
-                    messages=[
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-            else:
-                mock_create.assert_called_with(
-                    engine=expected_model,
-                    messages=[
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-
-            # Prompt and sys_prompt
-            test_data = {
-                'context': context,
-                'questions': questions,
-                'sys_prompt': sys_prompt
-            }
-            openai_model.predict(context, test_data)
-            if is_openai_1_0:
-                mock_create.assert_called_with(
-                    model=expected_model,
-                    messages=[
-                        {'role': 'system', 'content': sys_prompt},
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-            else:
-                mock_create.assert_called_with(
-                    engine=expected_model,
-                    messages=[
-                        {'role': 'system', 'content': sys_prompt},
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-
-            # Prompt and history
-            test_data = {
-                'context': context,
-                'questions': questions,
-                'history': history
-            }
-            openai_model.predict(context, test_data)
-            if is_openai_1_0:
-                mock_create.assert_called_with(
-                    model=expected_model,
-                    messages=[
-                        *history,
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-            else:
-                mock_create.assert_called_with(
-                    engine=expected_model,
-                    messages=[
-                        *history,
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-
-            # Prompt, history, and sys_prompt
-            test_data = {
-                'context': context,
-                'questions': questions,
-                'history': history,
-                'sys_prompt': sys_prompt
-            }
-            openai_model.predict(context, test_data)
-            if is_openai_1_0:
-                mock_create.assert_called_with(
-                    model=expected_model,
-                    messages=[
-                        {'role': 'system', 'content': sys_prompt},
-                        *history,
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-            else:
-                mock_create.assert_called_with(
-                    engine=expected_model,
-                    messages=[
-                        {'role': 'system', 'content': sys_prompt},
-                        *history,
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
+        # Prompt, history, and sys_prompt
+        test_data = {
+            'context': params['context'],
+            'questions': questions,
+            'history': history,
+            'sys_prompt': sys_prompt
+        }
+        self.assert_called_with(params, mock_result, test_data,
+                                sys_prompt=sys_prompt, history=history,
+                                questions=questions)
 
     @pytest.mark.skipif(sys.version_info.minor <= 6,
                         reason='Openai not supported for older versions')
     def test_predict_call_str(self):
-        # test creating the OpenaiWrapperModel and
-        # calling the predict function
-        api_type = 'azure'
-        api_base = 'https://mock.openai.azure.com/'
-        api_version = '2023-03-15-preview'
-        api_key = 'mock'
-        context = ''
-        questions = 'How to convert 10^9/l to liter?'
-        is_openai_1_0 = False
-        if not hasattr(openai, 'OpenAI'):
-            mock_function = 'openai.ChatCompletion.create'
-        else:
-            mock_function = 'openai.resources.chat.completions.Completions.create'
-            is_openai_1_0 = True
+        params = self.get_model_params()
+        questions = self.QUESTION
+        expected_content = self.EXPECTED_ANSWER
+        mock_result = self.create_mock_result(expected_content, params['is_openai_1_0'])
 
-        expected_model = 'gpt-4-32k'
-        mock_result = self.create_mock_result('mock', is_openai_1_0)
-
-        openai_model = OpenaiWrapperModel(
-            api_type, api_base, api_version, api_key)
-
-        # mock the openai create function
-        with patch(mock_function) as mock_create:
-            # wrap return value in mock class with read method
-            mock_create.return_value = mock_result
-            context = {}
-
-            # Only prompt
-            test_data = questions
-            openai_model.predict(context, test_data)
-            if is_openai_1_0:
-                mock_create.assert_called_with(
-                    model=expected_model,
-                    messages=[
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-            else:
-                mock_create.assert_called_with(
-                    engine=expected_model,
-                    messages=[
-                        {'role': 'user', 'content': questions}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
+        # Only prompt
+        test_data = questions
+        self.assert_called_with(params, mock_result, test_data,
+                                questions=questions)
 
     @pytest.mark.skipif(sys.version_info.minor <= 6,
                         reason='Openai not supported for older versions')
     def test_predict_call_list_of_str(self):
-        # test creating the OpenaiWrapperModel and
-        # calling the predict function
-        api_type = 'azure'
-        api_base = 'https://mock.openai.azure.com/'
-        api_version = '2023-03-15-preview'
-        api_key = 'mock'
-        context = ''
-        questions = ['How to convert 10^9/l to liter?']
-        is_openai_1_0 = False
-        if not hasattr(openai, 'OpenAI'):
-            mock_function = 'openai.ChatCompletion.create'
-        else:
-            mock_function = 'openai.resources.chat.completions.Completions.create'
-            is_openai_1_0 = True
+        params = self.get_model_params()
+        questions = self.QUESTION
+        expected_content = self.EXPECTED_ANSWER
+        mock_result = self.create_mock_result(expected_content, params['is_openai_1_0'])
 
-        expected_model = 'gpt-4-32k'
-        mock_result = self.create_mock_result('mock', is_openai_1_0)
-
-        openai_model = OpenaiWrapperModel(
-            api_type, api_base, api_version, api_key)
-
-        # mock the openai create function
-        with patch(mock_function) as mock_create:
-            # wrap return value in mock class with read method
-            mock_create.return_value = mock_result
-            context = {}
-
-            # Only prompt
-            test_data = questions
-            openai_model.predict(context, test_data)
-            if is_openai_1_0:
-                mock_create.assert_called_with(
-                    model=expected_model,
-                    messages=[
-                        {'role': 'user', 'content': questions[0]}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-            else:
-                mock_create.assert_called_with(
-                    engine=expected_model,
-                    messages=[
-                        {'role': 'user', 'content': questions[0]}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
+        # Only prompt
+        test_data = [questions]
+        self.assert_called_with(params, mock_result, test_data,
+                                questions=questions)
 
     @pytest.mark.skipif(sys.version_info.minor <= 6,
                         reason='Openai not supported for older versions')
     def test_predict_call_series(self):
-        # test creating the OpenaiWrapperModel and
-        # calling the predict function
-        api_type = 'azure'
-        api_base = 'https://mock.openai.azure.com/'
-        api_version = '2023-03-15-preview'
-        api_key = 'mock'
-        context = ''
-        questions = pd.Series('How to convert 10^9/l to liter?')
-        is_openai_1_0 = False
-        if not hasattr(openai, 'OpenAI'):
-            mock_function = 'openai.ChatCompletion.create'
-        else:
-            mock_function = 'openai.resources.chat.completions.Completions.create'
-            is_openai_1_0 = True
+        params = self.get_model_params()
+        questions = self.QUESTION
+        expected_content = self.EXPECTED_ANSWER
+        mock_result = self.create_mock_result(expected_content, params['is_openai_1_0'])
 
-        expected_model = 'gpt-4-32k'
-        mock_result = self.create_mock_result('mock', is_openai_1_0)
-
-        openai_model = OpenaiWrapperModel(
-            api_type, api_base, api_version, api_key)
-
-        # mock the openai create function
-        with patch(mock_function) as mock_create:
-            # wrap return value in mock class with read method
-            mock_create.return_value = mock_result
-            context = {}
-
-            # Only prompt
-            test_data = questions
-            openai_model.predict(context, test_data)
-            if is_openai_1_0:
-                mock_create.assert_called_with(
-                    model=expected_model,
-                    messages=[
-                        {'role': 'user', 'content': questions[0]}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
-            else:
-                mock_create.assert_called_with(
-                    engine=expected_model,
-                    messages=[
-                        {'role': 'user', 'content': questions[0]}
-                    ],
-                    temperature=openai_model.temperature,
-                    max_tokens=openai_model.max_tokens,
-                    top_p=openai_model.top_p,
-                    frequency_penalty=openai_model.frequency_penalty,
-                    presence_penalty=openai_model.presence_penalty,
-                    stop=openai_model.stop
-                )
+        # Only prompt
+        test_data = pd.Series(questions)
+        self.assert_called_with(params, mock_result, test_data,
+                                questions=questions)


### PR DESCRIPTION
If the input DataFrame to `model.predict` has `"sys_prompt"` and/or `"history"` columns, they are used to provide the system prompt and history of the chat to the API call respectively, along with the prompt itself in the `"questions"` column.

For each prompt, the `"sys_prompt"` should be a string, while the `"history"` should be a list of dictionaries containing the messages. For example:

```python
data = {
    'sys_prompt' : ['You are a helpful assistant', 'Your responses should always be in all CAPS'],
    'history' : [
        [
            {'role': 'user', 'content': 'What is the capital of France?'},
            {'role': 'assistant', 'content': 'The capital of France is Paris.'}
        ],
        [] # empty history for second question
    ],
    'questions' : ['What is its population?', 'Who is the president of the United States?']
}
df = pd.DataFrame(data)
openai_model.predict(df)

>>> array(['As of the latest reports, the population of Paris is approximately 2.16 million people as of 2021. However, the population significantly increases to around 10.8 million when considering the broader metropolitan area.',
       'AS OF MY LAST UPDATE, THE PRESIDENT OF THE UNITED STATES IS JOE BIDEN.'],
      dtype='<U217')
```