### PR TITLE
make input column customizable for openai wrapper

### DIFF
--- a/python/ml_wrappers/model/openai_wrapper.py
+++ b/python/ml_wrappers/model/openai_wrapper.py
@@ -115,7 +115,7 @@ class OpenaiWrapperModel(object):
     def __init__(self, api_type, api_base, api_version, api_key,
                  engine="gpt-4-32k", temperature=0.7, max_tokens=800,
                  top_p=0.95, frequency_penalty=0, presence_penalty=0,
-                 stop=None):
+                 stop=None, input_col='prompt'):
         """Initialize the model.
 
         :param api_type: The type of the API.
@@ -140,6 +140,8 @@ class OpenaiWrapperModel(object):
         :type presence_penalty: float
         :param stop: The stop.
         :type stop: list
+        :param input_col: The name of the input column.
+        :type input_col: str
         """
         self.api_type = api_type
         self.api_base = api_base
@@ -152,6 +154,7 @@ class OpenaiWrapperModel(object):
         self.frequency_penalty = frequency_penalty
         self.presence_penalty = presence_penalty
         self.stop = stop
+        self.input_col = input_col
 
     def _call_webservice(self, data, history=None, sys_prompt=None):
         """Common code to call the webservice.
@@ -213,6 +216,27 @@ class OpenaiWrapperModel(object):
                 answers.append(replace_backtick_chars(response.choices[0].message.content))
         return np.array(answers)
 
+    def _get_input_data(self, model_input, input_col):
+        if isinstance(model_input, dict):
+            prompts = pd.Series(model_input[input_col])
+            if 'history' in model_input:
+                if isinstance(model_input[input_col], str):
+                    history = pd.Series([model_input['history']])
+                else:
+                    history = pd.Series(model_input['history'])
+            else:
+                history = None
+            if 'sys_prompt' in model_input:
+                sys_prompt = pd.Series(model_input['sys_prompt'])
+            else:
+                sys_prompt = None
+        else:
+            prompts = model_input[input_col]
+            history = model_input.get('history')
+            sys_prompt = model_input.get('sys_prompt')
+
+        return prompts, history, sys_prompt
+
     def predict(self, context, model_input=None):
         """Predict using the model.
 
@@ -236,23 +260,12 @@ class OpenaiWrapperModel(object):
             questions = pd.Series(model_input)
             history = None
             sys_prompt = None
-        elif isinstance(model_input, dict):
-            questions = pd.Series(model_input['questions'])
-            if 'history' in model_input:
-                if isinstance(model_input['questions'], str):
-                    history = pd.Series([model_input['history']])
-                else:
-                    history = pd.Series(model_input['history'])
-            else:
-                history = None
-            if 'sys_prompt' in model_input:
-                sys_prompt = pd.Series(model_input['sys_prompt'])
-            else:
-                sys_prompt = None
         else:
-            questions = model_input['questions']
-            history = model_input.get('history')
-            sys_prompt = model_input.get('sys_prompt')
+            try:
+                questions, history, sys_prompt = self._get_input_data(model_input, self.input_col)
+            except KeyError:
+                # Fallback option keep support for older versions
+                questions, history, sys_prompt = self._get_input_data(model_input, 'questions')
 
         result = self._call_webservice(
             questions,

--- a/python/ml_wrappers/model/openai_wrapper.py
+++ b/python/ml_wrappers/model/openai_wrapper.py
@@ -28,6 +28,8 @@ AZURE = 'azure'
 CHAT_COMPLETION = 'ChatCompletion'
 CONTENT = 'content'
 OPENAI = 'OpenAI'
+HISTORY = 'history'
+SYS_PROMPT = 'sys_prompt'
 
 
 def replace_backtick_chars(message):
@@ -219,21 +221,21 @@ class OpenaiWrapperModel(object):
     def _get_input_data(self, model_input, input_col):
         if isinstance(model_input, dict):
             prompts = pd.Series(model_input[input_col])
-            if 'history' in model_input:
+            if HISTORY in model_input:
                 if isinstance(model_input[input_col], str):
-                    history = pd.Series([model_input['history']])
+                    history = pd.Series([model_input[HISTORY]])
                 else:
-                    history = pd.Series(model_input['history'])
+                    history = pd.Series(model_input[HISTORY])
             else:
                 history = None
-            if 'sys_prompt' in model_input:
-                sys_prompt = pd.Series(model_input['sys_prompt'])
+            if SYS_PROMPT in model_input:
+                sys_prompt = pd.Series(model_input[SYS_PROMPT])
             else:
                 sys_prompt = None
         else:
             prompts = model_input[input_col]
-            history = model_input.get('history')
-            sys_prompt = model_input.get('sys_prompt')
+            history = model_input.get(HISTORY)
+            sys_prompt = model_input.get(SYS_PROMPT)
 
         return prompts, history, sys_prompt
 

--- a/tests/main/test_openai_wrapper.py
+++ b/tests/main/test_openai_wrapper.py
@@ -104,7 +104,7 @@ class TestOpenaiWrapperModel(object):
             }
         return mock_result
 
-    def get_model_params(self):
+    def get_model_params(self, **kwargs):
         ret = {
             'context': '',
             'expected_model': 'gpt-4-32k'
@@ -114,7 +114,7 @@ class TestOpenaiWrapperModel(object):
         api_version = '2023-03-15-preview'
         api_key = 'mock'
         ret['openai_model'] = OpenaiWrapperModel(
-            api_type, api_base, api_version, api_key)
+            api_type, api_base, api_version, api_key, **kwargs)
         is_openai_1_0 = False
         if not hasattr(openai, 'OpenAI'):
             mock_function = 'openai.ChatCompletion.create'
@@ -270,6 +270,19 @@ class TestOpenaiWrapperModel(object):
                                 sys_prompt=sys_prompt, history=history,
                                 questions=questions)
 
+        # Prompt with new input column name
+        test_data = pd.DataFrame(data=[[params['context'], questions]],
+                                 columns=['context', 'prompt'])
+        self.assert_called_with(params, mock_result, test_data,
+                                questions=questions)
+
+        # Prompt with custom input column name
+        params = self.get_model_params(input_col='custom_prompt')
+        test_data = pd.DataFrame(data=[[params['context'], questions]],
+                                 columns=['context', 'custom_prompt'])
+        self.assert_called_with(params, mock_result, test_data,
+                                questions=questions)
+
     @pytest.mark.skipif(sys.version_info.minor <= 6,
                         reason='Openai not supported for older versions')
     def test_predict_call_dict(self):
@@ -317,6 +330,23 @@ class TestOpenaiWrapperModel(object):
                                 sys_prompt=sys_prompt, history=history,
                                 questions=questions)
 
+        # Prompt with new input column name
+        test_data = test_data = {
+            'context': [params['context']],
+            'prompt': [questions]
+        }
+        self.assert_called_with(params, mock_result, test_data,
+                                questions=questions)
+
+        # Prompt with custom input column name
+        params = self.get_model_params(input_col='custom_prompt')
+        test_data = test_data = {
+            'context': [params['context']],
+            'custom_prompt': [questions]
+        }
+        self.assert_called_with(params, mock_result, test_data,
+                                questions=questions)
+
     @pytest.mark.skipif(sys.version_info.minor <= 6,
                         reason='Openai not supported for older versions')
     def test_predict_call_dict_of_str(self):
@@ -362,6 +392,23 @@ class TestOpenaiWrapperModel(object):
         }
         self.assert_called_with(params, mock_result, test_data,
                                 sys_prompt=sys_prompt, history=history,
+                                questions=questions)
+
+        # Prompt with new input column name
+        test_data = test_data = {
+            'context': [params['context']],
+            'prompt': questions
+        }
+        self.assert_called_with(params, mock_result, test_data,
+                                questions=questions)
+
+        # Prompt with custom input column name
+        params = self.get_model_params(input_col='custom_prompt')
+        test_data = test_data = {
+            'context': [params['context']],
+            'custom_prompt': questions
+        }
+        self.assert_called_with(params, mock_result, test_data,
                                 questions=questions)
 
     @pytest.mark.skipif(sys.version_info.minor <= 6,


### PR DESCRIPTION
Currently, when calling the `.predict()` method of the openai wrapper with a `dict` or `pandas.DataFrame`, the method looks for the `"questions"` key/column in the input to get the prompts that need to be sent to the OpenAI API to make the predictions.

The default behavior has now been changed to look for `"prompt"` key/column in the input, and falling back to the `"questions"` column if not found to maintain backwards compatibility. Additionally, the users can now also specify a different column name of their choice by specifiying the `input_col` keyword-argument when initializing the wrapper model.

```python
from ml_wrappers.model import OpenaiWrapperModel

model = OpenaiWrapperModel(
    API_TYPE,
    API_BASE,
    API_VERSION,
    API_KEY,
    input_col='my_input_col')
```