### PR TITLE
Update ml-wrappers release script to python 3.9 to fix test failures

### DIFF
--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -34,57 +34,68 @@ jobs:
       with:
         auto-update-conda: true
         python-version: ${{ matrix.pythonVersion }}
+
     - if: ${{ matrix.operatingSystem == 'macos-latest' }}
       name: Use Homebrew to install libomp on MacOS
       shell: bash -l {0}
       run: |
         brew install libomp
+
     - if: ${{ matrix.operatingSystem == 'windows-latest' }}
       name: Install pytorch on windows for python 3.8 to 3.10
       shell: bash -l {0}
       run: |
         conda install --yes --quiet "pytorch<2.0.0" torchvision captum cpuonly "libtiff<4.5.0" -c pytorch -c conda-forge --strict-channel-priority
+
     - if: ${{ matrix.operatingSystem == 'ubuntu-latest' }}
       name: Install pytorch on ubuntu for python 3.8 to 3.10
       shell: bash -l {0}
       run: |
         conda install --yes --quiet "pytorch<2.0.0" torchvision captum cpuonly -c pytorch -c conda-forge --strict-channel-priority
+
     - if: ${{ matrix.operatingSystem == 'macos-latest' }}
       name: Install pytorch on MacOS for python 3.8 to 3.10
       shell: bash -l {0}
       run: |
         conda install --yes --quiet "pytorch<2.0.0" torchvision captum -c pytorch -c conda-forge --strict-channel-priority
+
     - if: ${{ matrix.operatingSystem == 'macos-latest' }}
       name: Install lightgbm from conda on MacOS
       shell: bash -l {0}
       run: |
         conda install --yes -c conda-forge lightgbm
-    - name: Install backwards-compatible keras for transformers
+
+    - name: Install backwards-compatible tf-keras for transformers
       shell: bash -l {0}
       run: |
         pip install tf-keras
-        pip install keras==2.15
+
     - name: Install package
       shell: bash -l {0}
       run: |
         pip install -e ./python
+
     - name: Install dev dependencies
       shell: bash -l {0}
       run: |
         pip install -r requirements-dev.txt
+
     - name: Install test dependencies
       shell: bash -l {0}
       run: |
         pip install -r requirements-test.txt
+
     - if: ${{ matrix.openaiVersion != 'openai-latest' }}
       name: Install openai version ${{ matrix.openaiVersion }}
       shell: bash -l {0}
       run: |
         pip install openai==${{ matrix.openaiVersion }}
+
     - name: Test with pytest
       shell: bash -l {0}
       run: |
         pytest ./tests/main -s -v --durations=10 --cov='ml_wrappers' --cov-report=xml --cov-report=html
+
     - name: Upload code coverage results
       uses: actions/upload-artifact@v3
       with:
@@ -92,6 +103,7 @@ jobs:
         path: htmlcov
       # Use always() to always run this step to publish test results when there are test failures
       if: ${{ always() }}
+
     - if: ${{ (matrix.operatingSystem == 'windows-latest') && (matrix.pythonVersion == '3.8') }}
       name: Upload to codecov
       id: codecovupload1
@@ -105,6 +117,7 @@ jobs:
         flags: unittests
         name: codecov-umbrella
         verbose: true
+
     - if: ${{ (steps.codecovupload1.outcome == 'failure') && (matrix.pythonVersion == '3.8') && (matrix.operatingSystem == 'windows-latest') }}
       name: Retry upload to codecov
       id: codecovupload2
@@ -118,6 +131,7 @@ jobs:
         flags: unittests
         name: codecov-umbrella
         verbose: true
+
     - name: Set codecov status
       if: ${{ (matrix.pythonVersion == '3.8') && (matrix.operatingSystem == 'windows-latest') }}
       shell: bash

--- a/.github/workflows/release-ml-wrappers.yml
+++ b/.github/workflows/release-ml-wrappers.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
-          python-version: 3.8
+          python-version: 3.9
 
       - if: ${{ matrix.operatingSystem != 'macos-latest' }}
         name: Install pytorch on non-MacOS
@@ -45,10 +45,19 @@ jobs:
           python -m pip install --upgrade pip
           pip install --upgrade setuptools wheel twine
 
-      - name: install requirements for ml-wrappers
+      - name: Install backwards-compatible tf-keras for transformers
+        shell: bash -l {0}
+        run: |
+          pip install tf-keras
+
+      - name: Install dev dependencies
         shell: bash -l {0}
         run: |
           pip install -r requirements-dev.txt
+    
+      - name: Install test dependencies
+        shell: bash -l {0}
+        run: |
           pip install -r requirements-test.txt
 
       - name: pip freeze


### PR DESCRIPTION
The release of ml-wrappers to pypi failed because it required some updates to the release github actions workflow.
This PR updates the release script to pypi for ml-wrappers:
1.) Update to python 3.9
2.) Install tf-keras which is needed for transformers package for one of the tests, eg see code throwing error in latest transformers package:
https://github.com/huggingface/transformers/blob/87134662f73d5e89bb015531ddd1d4662371d317/src/transformers/activations_tf.py#L28
```
    if parse(keras.__version__).major > 2:
        raise ValueError(
            "Your currently installed version of Keras is Keras 3, but this is not yet supported in "
            "Transformers. Please install the backwards-compatible tf-keras package with "
            "`pip install tf-keras`."
        )
```
The release script was run and there was a successful release to pypi test here:
https://github.com/microsoft/ml-wrappers/actions/runs/10496459124
It will be released to prod after this PR is merged.
See successful package release here:
https://test.pypi.org/project/ml-wrappers/0.5.6/