### PR TITLE
Update upload-artifact to v4 and fix release script in ml-wrappers

### DIFF
--- a/.github/workflows/CI-python-AutoML.yml
+++ b/.github/workflows/CI-python-AutoML.yml
@@ -66,7 +66,7 @@ jobs:
       run: |
         pytest ./tests/automl -s -v --durations=10 --cov='ml_wrappers' --cov-report=xml --cov-report=html
     - name: Upload code coverage results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.packageDirectory }}-code-coverage-results
         path: htmlcov

--- a/.github/workflows/CI-python-minimal.yml
+++ b/.github/workflows/CI-python-minimal.yml
@@ -42,9 +42,9 @@ jobs:
       run: |
         pytest ./tests/minimal -s -v --durations=10 --cov='ml_wrappers' --cov-report=xml --cov-report=html
     - name: Upload code coverage results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: ${{ matrix.packageDirectory }}-code-coverage-results
+        name: ${{ matrix.packageDirectory }}-${{ matrix.pythonVersion }}-${{ matrix.operatingSystem }}-code-coverage-results
         path: htmlcov
       # Use always() to always run this step to publish test results when there are test failures
       if: ${{ always() }}

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -98,9 +98,9 @@ jobs:
         pytest ./tests/main -s -v --durations=10 --cov='ml_wrappers' --cov-report=xml --cov-report=html
 
     - name: Upload code coverage results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: ${{ matrix.packageDirectory }}-code-coverage-results
+        name: ${{ matrix.packageDirectory }}-${{ matrix.openaiVersion }}-${{ matrix.pythonVersion }}-${{ matrix.operatingSystem }}-code-coverage-results
         path: htmlcov
       # Use always() to always run this step to publish test results when there are test failures
       if: ${{ always() }}

--- a/.github/workflows/release-ml-wrappers.yml
+++ b/.github/workflows/release-ml-wrappers.yml
@@ -27,17 +27,10 @@ jobs:
           auto-update-conda: true
           python-version: 3.9
 
-      - if: ${{ matrix.operatingSystem != 'macos-latest' }}
-        name: Install pytorch on non-MacOS
+      - name: Install pytorch on non-MacOS
         shell: bash -l {0}
         run: |
           conda install --yes --quiet pytorch torchvision captum cpuonly -c pytorch -c conda-forge --strict-channel-priority
-
-      - if: ${{ matrix.operatingSystem == 'macos-latest' }}
-        name: Install Anaconda packages on MacOS, which should not include cpuonly according to official docs
-        shell: bash -l {0}
-        run: |
-          conda install --yes --quiet pytorch torchvision captum -c pytorch
 
       - name: update and upgrade pip, setuptools, wheel, and twine
         shell: bash -l {0}
@@ -80,9 +73,9 @@ jobs:
         run: pytest ./tests/main
 
       - name: Upload a ml-wrappers build result
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: ml_wrappers
+          name: ml_wrappers-${{ github.event.inputs.releaseType }}
           path: python/dist/
 
       # publish to PyPI


### PR DESCRIPTION
Fixes error:

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```

Coplot summary:

This pull request includes several updates to the GitHub Actions workflows, focusing on upgrading the `upload-artifact` action version and simplifying the installation steps for pytorch on non-MacOS systems.

### Workflow updates:

* [`.github/workflows/CI-python-AutoML.yml`](diffhunk://#diff-ac99add371ffd03527acbe4b88283ab0be579c27163c5c71a6bacc559980620aL69-R69): Updated the `upload-artifact` action from version `v3` to `v4`.
* [`.github/workflows/CI-python-minimal.yml`](diffhunk://#diff-24d24a406741debffb0b092c1a77e15daeeebfcf1787e4db0b0c9ce28b2ba618L45-R45): Updated the `upload-artifact` action from version `v3` to `v4`.
* [`.github/workflows/CI-python.yml`](diffhunk://#diff-2b75812bc12c9a72b073df40c11ceda4af97cc64083831530ca88c683447b387L101-R101): Updated the `upload-artifact` action from version `v3` to `v4`.
* [`.github/workflows/release-ml-wrappers.yml`](diffhunk://#diff-b45cea7683d7a1bc259e000cc5e86807cfae34b3ed4374635258212820129b3aL30-L41): Simplified the installation steps for pytorch on non-MacOS systems by removing conditional checks for the operating system.
* [`.github/workflows/release-ml-wrappers.yml`](diffhunk://#diff-b45cea7683d7a1bc259e000cc5e86807cfae34b3ed4374635258212820129b3aL83-R76): Updated the `upload-artifact` action from version `v2` to `v4`.